### PR TITLE
Determine proc struct p_comm/path offset at runtime

### DIFF
--- a/installer/include/version.h
+++ b/installer/include/version.h
@@ -2,7 +2,7 @@
 #define VERSION_H_
 
 #define VERSION "2.2.0 BETA"
-#define MIN_FW 672
+#define MIN_FW 500
 #define MAX_FW 1202
 
 #endif

--- a/kpayload/include/freebsd_helper.h
+++ b/kpayload/include/freebsd_helper.h
@@ -148,16 +148,26 @@ TYPE_FIELD(struct ucred *p_ucred, 0x40);
 TYPE_FIELD(struct filedesc *p_fd, 0x48);
 TYPE_FIELD(int pid, 0xB0);
 TYPE_FIELD(struct vmspace *p_vmspace, 0x168);
-// TODO: Varies per FW
-// TYPE_FIELD(char p_comm[32], 0x3E8); // 4.00-4.50
-// TYPE_FIELD(char p_comm[32], 0x43C); // 4.55-4.74
-// TYPE_FIELD(char p_comm[32], 0x44C); // 5.00-5.07
-TYPE_FIELD(char p_comm[32], 0x454); // 5.50-5.56 and >= 6.50 (Has it changed since 6.50?)
-// TYPE_FIELD(char p_comm[32], 0x450); // 6.00-6.20
 TYPE_FIELD(char titleid[16], 0x390);
 TYPE_FIELD(char contentid[64], 0x3D4);
-TYPE_FIELD(char path[64], 0x474);
-
+// Varies per FW
+// TYPE_FIELD(char p_comm[32], 0x350); // <3.55
+// TYPE_FIELD(char p_comm[32], 0x3E0); // 3.55-3.70
+// TYPE_FIELD(char p_comm[32], 0x3F0); // 4.00-4.50
+// TYPE_FIELD(char p_comm[32], 0x444); // 4.55-4.74
+// TYPE_FIELD(char p_comm[32], 0x44C); // 5.00-5.07
+// TYPE_FIELD(char p_comm[32], 0x454); // 5.50-5.56
+// TYPE_FIELD(char p_comm[32], 0x450); // 6.00-6.20
+// TYPE_FIELD(char p_comm[32], 0x454); // 6.50+ (TODO: Confirm it hasn't changed since 6.50)
+// Varies per FW
+// TYPE_FIELD(char path[64], 0x370); // <3.55
+// TYPE_FIELD(char path[64], 0x400); // 3.55-3.70
+// TYPE_FIELD(char path[64], 0x410); // 4.00-4.50
+// TYPE_FIELD(char path[64], 0x464); // 4.55-4.74
+// TYPE_FIELD(char path[64], 0x46C); // 5.00-5.07
+// TYPE_FIELD(char path[64], 0x474); // 5.50-5.56
+// TYPE_FIELD(char path[64], 0x470); // 6.00-6.20
+// TYPE_FIELD(char path[64], 0x474); // 6.50+ (TODO: Confirm it hasn't changed since 6.50)
 TYPE_END();
 
 #endif

--- a/kpayload/include/offsets.h
+++ b/kpayload/include/offsets.h
@@ -1,9 +1,13 @@
 #ifndef OFFSETS_H_
 #define OFFSETS_H_
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include "sections.h"
+
+// Forward declaration for fw_offsets
+extern const struct kpayload_offsets *fw_offsets PAYLOAD_BSS;
 
 // clang-format off
 
@@ -132,11 +136,34 @@ struct kpayload_offsets {
 
   // SceShellCore patches - disable screenshot block
   uint32_t disable_screenshot_patch;
+
+  // Process structure offsets
+  uint32_t proc_p_comm_offset;
+  uint32_t proc_path_offset;
 };
 
-// Lookup function: implemented elsewhere
+// clang-format on
+
+// Offsets initializer function
 PAYLOAD_CODE const struct kpayload_offsets *get_offsets_for_fw(uint16_t fw_version);
 
-// clang-format on
+// Forward declaration for proc structure
+struct proc;
+
+// Get pointer to p_comm field (process name)
+PAYLOAD_CODE static inline char *proc_get_p_comm(struct proc *p) {
+  if (!fw_offsets) {
+    return NULL;
+  }
+  return (char *)((uintptr_t)p + fw_offsets->proc_p_comm_offset);
+}
+
+// Get pointer to path field (full path to ELF)
+PAYLOAD_CODE static inline char *proc_get_path(struct proc *p) {
+  if (!fw_offsets) {
+    return NULL;
+  }
+  return (char *)((uintptr_t)p + fw_offsets->proc_path_offset);
+}
 
 #endif

--- a/kpayload/source/fpkg.c
+++ b/kpayload/source/fpkg.c
@@ -11,8 +11,6 @@
 #include "sections.h"
 #include "sparse.h"
 
-extern const struct kpayload_offsets *fw_offsets PAYLOAD_BSS;
-
 extern int (*_sx_xlock)(struct sx *sx, int opts, const char *file, int line) PAYLOAD_BSS;
 extern int (*_sx_xunlock)(struct sx *sx) PAYLOAD_BSS;
 extern int (*fpu_kern_enter)(struct thread *td, struct fpu_kern_ctx *ctx, uint32_t flags) PAYLOAD_BSS;
@@ -379,7 +377,7 @@ PAYLOAD_CODE int my_sceSblKeymgrSmCallfunc_npdrm_decrypt_rif_new(union keymgr_pa
       goto err;
     }
 
-    // XXX: Sorry, I'm lazy to refactor this crappy code :D basically, we're copying decrypted data to proper place,
+    // TODO: Sorry, I'm lazy to refactor this crappy code :D basically, we're copying decrypted data to proper place,
     // consult with kernel code if offsets needs to be changed
     memcpy(response->decrypt_entire_rif.raw, request->decrypt_entire_rif.rif.digest, sizeof(request->decrypt_entire_rif.rif.digest) + sizeof(request->decrypt_entire_rif.rif.data));
     memset(response->decrypt_entire_rif.raw + sizeof(request->decrypt_entire_rif.rif.digest) + sizeof(request->decrypt_entire_rif.rif.data), '\0', sizeof(response->decrypt_entire_rif.raw) - (sizeof(request->decrypt_entire_rif.rif.digest) + sizeof(request->decrypt_entire_rif.rif.data)));
@@ -451,7 +449,7 @@ PAYLOAD_CODE static int my_sceSblKeymgrInvalidateKey__sx_xlock(struct sx *sx, in
   }
 
 done:
-  // XXX: no need to call SX unlock because we'll jump to original code which expects SX is already locked
+  // no need to call SX unlock because we'll jump to original code which expects SX is already locked
   return ret;
 }
 

--- a/kpayload/source/fself.c
+++ b/kpayload/source/fself.c
@@ -12,8 +12,6 @@
 
 #define PAGE_SIZE 0x4000
 
-extern const struct kpayload_offsets *fw_offsets PAYLOAD_BSS;
-
 extern void *(*malloc)(unsigned long size, void *type, int flags)PAYLOAD_BSS;
 extern void (*free)(void *addr, void *type) PAYLOAD_BSS;
 extern char *(*strstr)(const char *haystack, const char *needle)PAYLOAD_BSS;

--- a/kpayload/source/hooks.c
+++ b/kpayload/source/hooks.c
@@ -63,7 +63,8 @@ PAYLOAD_CODE int sys_proc_list(struct thread *td, struct sys_proc_list_args *uap
     num = *uap->num;
     p = *ALLPROC;
     for (int i = 0; i < num; i++) {
-      memcpy(uap->procs[i].p_comm, p->p_comm, sizeof(uap->procs[i].p_comm));
+      char *p_comm = proc_get_p_comm(p);
+      memcpy(uap->procs[i].p_comm, p_comm, sizeof(uap->procs[i].p_comm));
       uap->procs[i].pid = p->pid;
 
       if (!(p = p->p_forw)) {
@@ -160,8 +161,10 @@ PAYLOAD_CODE void *get_syscall(uint64_t n) {
 
 int sys_proc_info_handle(struct proc *p, struct sys_proc_info_args *args) {
   args->pid = p->pid;
-  memcpy(args->name, p->p_comm, sizeof(args->name));
-  memcpy(args->path, p->path, sizeof(args->path));
+  char *p_comm = proc_get_p_comm(p);
+  memcpy(args->name, p_comm, sizeof(args->name));
+  char *path = proc_get_path(p);
+  memcpy(args->path, path, sizeof(args->path));
   memcpy(args->titleid, p->titleid, sizeof(args->titleid));
   memcpy(args->contentid, p->contentid, sizeof(args->contentid));
   return 0;

--- a/kpayload/source/offsets/1000.c
+++ b/kpayload/source/offsets/1000.c
@@ -129,6 +129,10 @@ const struct kpayload_offsets offsets_1000 PAYLOAD_RDATA = {
 
   // SceShellCore patches - disable screenshot block
   .disable_screenshot_patch        = 0x000CF8B6,
+
+  // Process structure offsets
+  .proc_p_comm_offset = 0x454,
+  .proc_path_offset   = 0x474,
 };
 
 // clang-format on

--- a/kpayload/source/offsets/1001.c
+++ b/kpayload/source/offsets/1001.c
@@ -129,6 +129,10 @@ const struct kpayload_offsets offsets_1001 PAYLOAD_RDATA = {
 
   // SceShellCore patches - disable screenshot block
   .disable_screenshot_patch        = 0x000CF8B6,
+
+  // Process structure offsets
+  .proc_p_comm_offset = 0x454,
+  .proc_path_offset   = 0x474,
 };
 
 // clang-format on

--- a/kpayload/source/offsets/1050.c
+++ b/kpayload/source/offsets/1050.c
@@ -129,6 +129,10 @@ const struct kpayload_offsets offsets_1050 PAYLOAD_RDATA = {
 
   // SceShellCore patches - disable screenshot block
   .disable_screenshot_patch        = 0x000CF876,
+
+  // Process structure offsets
+  .proc_p_comm_offset = 0x454,
+  .proc_path_offset   = 0x474,
 };
 
 // clang-format on

--- a/kpayload/source/offsets/1070.c
+++ b/kpayload/source/offsets/1070.c
@@ -129,6 +129,10 @@ const struct kpayload_offsets offsets_1070 PAYLOAD_RDATA = {
 
   // SceShellCore patches - disable screenshot block
   .disable_screenshot_patch        = 0x000CF876,
+
+  // Process structure offsets
+  .proc_p_comm_offset = 0x454,
+  .proc_path_offset   = 0x474,
 };
 
 // clang-format on

--- a/kpayload/source/offsets/1071.c
+++ b/kpayload/source/offsets/1071.c
@@ -129,6 +129,10 @@ const struct kpayload_offsets offsets_1071 PAYLOAD_RDATA = {
 
   // SceShellCore patches - disable screenshot block
   .disable_screenshot_patch        = 0x000CF876,
+
+  // Process structure offsets
+  .proc_p_comm_offset = 0x454,
+  .proc_path_offset   = 0x474,
 };
 
 // clang-format on

--- a/kpayload/source/offsets/1100.c
+++ b/kpayload/source/offsets/1100.c
@@ -129,6 +129,10 @@ const struct kpayload_offsets offsets_1100 PAYLOAD_RDATA = {
 
   // SceShellCore patches - disable screenshot block
   .disable_screenshot_patch        = 0x000CF876,
+
+  // Process structure offsets
+  .proc_p_comm_offset = 0x454,
+  .proc_path_offset   = 0x474,
 };
 
 // clang-format on

--- a/kpayload/source/offsets/1102.c
+++ b/kpayload/source/offsets/1102.c
@@ -129,6 +129,10 @@ const struct kpayload_offsets offsets_1102 PAYLOAD_RDATA = {
 
   // SceShellCore patches - disable screenshot block
   .disable_screenshot_patch        = 0x000CF876,
+
+  // Process structure offsets
+  .proc_p_comm_offset = 0x454,
+  .proc_path_offset   = 0x474,
 };
 
 // clang-format on

--- a/kpayload/source/offsets/1150.c
+++ b/kpayload/source/offsets/1150.c
@@ -129,6 +129,10 @@ const struct kpayload_offsets offsets_1150 PAYLOAD_RDATA = {
 
   // SceShellCore patches - disable screenshot block
   .disable_screenshot_patch        = 0x000D2216,
+
+  // Process structure offsets
+  .proc_p_comm_offset = 0x454,
+  .proc_path_offset   = 0x474,
 };
 
 // clang-format on

--- a/kpayload/source/offsets/1152.c
+++ b/kpayload/source/offsets/1152.c
@@ -129,6 +129,10 @@ const struct kpayload_offsets offsets_1152 PAYLOAD_RDATA = {
 
   // SceShellCore patches - disable screenshot block
   .disable_screenshot_patch        = 0x000D2216,
+
+  // Process structure offsets
+  .proc_p_comm_offset = 0x454,
+  .proc_path_offset   = 0x474,
 };
 
 // clang-format on

--- a/kpayload/source/offsets/1200.c
+++ b/kpayload/source/offsets/1200.c
@@ -129,6 +129,10 @@ const struct kpayload_offsets offsets_1200 PAYLOAD_RDATA = {
 
   // SceShellCore patches - disable screenshot block
   .disable_screenshot_patch        = 0x000D2216,
+
+  // Process structure offsets
+  .proc_p_comm_offset = 0x454,
+  .proc_path_offset   = 0x474,
 };
 
 // clang-format on

--- a/kpayload/source/offsets/1202.c
+++ b/kpayload/source/offsets/1202.c
@@ -129,6 +129,10 @@ const struct kpayload_offsets offsets_1202 PAYLOAD_RDATA = {
 
   // SceShellCore patches - disable screenshot block
   .disable_screenshot_patch        = 0x000D2216,
+
+  // Process structure offsets
+  .proc_p_comm_offset = 0x454,
+  .proc_path_offset   = 0x474,
 };
 
 // clang-format on

--- a/kpayload/source/offsets/505.c
+++ b/kpayload/source/offsets/505.c
@@ -129,6 +129,10 @@ const struct kpayload_offsets offsets_505 PAYLOAD_RDATA = {
 
   // SceShellCore patches - disable screenshot block
   .disable_screenshot_patch        = 0x000CB8C6,
+
+  // Process structure offsets
+  .proc_p_comm_offset = 0x44C,
+  .proc_path_offset   = 0x46C,
 };
 
 // clang-format on

--- a/kpayload/source/offsets/672.c
+++ b/kpayload/source/offsets/672.c
@@ -129,6 +129,10 @@ const struct kpayload_offsets offsets_672 PAYLOAD_RDATA = {
 
   // SceShellCore patches - disable screenshot block
   .disable_screenshot_patch        = 0x000DD2A6,
+
+  // Process structure offsets
+  .proc_p_comm_offset = 0x454,
+  .proc_path_offset   = 0x474,
 };
 
 // clang-format on

--- a/kpayload/source/offsets/700.c
+++ b/kpayload/source/offsets/700.c
@@ -129,6 +129,10 @@ const struct kpayload_offsets offsets_700 PAYLOAD_RDATA = {
 
   // SceShellCore patches - disable screenshot block
   .disable_screenshot_patch        = 0x000D61F6,
+
+  // Process structure offsets
+  .proc_p_comm_offset = 0x454,
+  .proc_path_offset   = 0x474,
 };
 
 // clang-format on

--- a/kpayload/source/offsets/701.c
+++ b/kpayload/source/offsets/701.c
@@ -129,6 +129,10 @@ const struct kpayload_offsets offsets_701 PAYLOAD_RDATA = {
 
   // SceShellCore patches - disable screenshot block
   .disable_screenshot_patch        = 0x000D61F6,
+
+  // Process structure offsets
+  .proc_p_comm_offset = 0x454,
+  .proc_path_offset   = 0x474,
 };
 
 // clang-format on

--- a/kpayload/source/offsets/702.c
+++ b/kpayload/source/offsets/702.c
@@ -129,6 +129,10 @@ const struct kpayload_offsets offsets_702 PAYLOAD_RDATA = {
 
   // SceShellCore patches - disable screenshot block
   .disable_screenshot_patch        = 0x000D61F6,
+
+  // Process structure offsets
+  .proc_p_comm_offset = 0x454,
+  .proc_path_offset   = 0x474,
 };
 
 // clang-format on

--- a/kpayload/source/offsets/750.c
+++ b/kpayload/source/offsets/750.c
@@ -129,6 +129,10 @@ const struct kpayload_offsets offsets_750 PAYLOAD_RDATA = {
 
   // SceShellCore patches - disable screenshot block
   .disable_screenshot_patch        = 0x000CD6B6,
+
+  // Process structure offsets
+  .proc_p_comm_offset = 0x454,
+  .proc_path_offset   = 0x474,
 };
 
 // clang-format on

--- a/kpayload/source/offsets/751.c
+++ b/kpayload/source/offsets/751.c
@@ -129,6 +129,10 @@ const struct kpayload_offsets offsets_751 PAYLOAD_RDATA = {
 
   // SceShellCore patches - disable screenshot block
   .disable_screenshot_patch        = 0x000CD6B6,
+
+  // Process structure offsets
+  .proc_p_comm_offset = 0x454,
+  .proc_path_offset   = 0x474,
 };
 
 // clang-format on

--- a/kpayload/source/offsets/755.c
+++ b/kpayload/source/offsets/755.c
@@ -129,6 +129,10 @@ const struct kpayload_offsets offsets_755 PAYLOAD_RDATA = {
 
   // SceShellCore patches - disable screenshot block
   .disable_screenshot_patch        = 0x000CD6B6,
+
+  // Process structure offsets
+  .proc_p_comm_offset = 0x454,
+  .proc_path_offset   = 0x474,
 };
 
 // clang-format on

--- a/kpayload/source/offsets/800.c
+++ b/kpayload/source/offsets/800.c
@@ -129,6 +129,10 @@ const struct kpayload_offsets offsets_800 PAYLOAD_RDATA = {
 
   // SceShellCore patches - disable screenshot block
   .disable_screenshot_patch        = 0x000CF3F6,
+
+  // Process structure offsets
+  .proc_p_comm_offset = 0x454,
+  .proc_path_offset   = 0x474,
 };
 
 // clang-format on

--- a/kpayload/source/offsets/801.c
+++ b/kpayload/source/offsets/801.c
@@ -129,6 +129,10 @@ const struct kpayload_offsets offsets_801 PAYLOAD_RDATA = {
 
   // SceShellCore patches - disable screenshot block
   .disable_screenshot_patch        = 0x000CF3F6,
+
+  // Process structure offsets
+  .proc_p_comm_offset = 0x454,
+  .proc_path_offset   = 0x474,
 };
 
 // clang-format on

--- a/kpayload/source/offsets/803.c
+++ b/kpayload/source/offsets/803.c
@@ -129,6 +129,10 @@ const struct kpayload_offsets offsets_803 PAYLOAD_RDATA = {
 
   // SceShellCore patches - disable screenshot block
   .disable_screenshot_patch        = 0x000CF3F6,
+
+  // Process structure offsets
+  .proc_p_comm_offset = 0x454,
+  .proc_path_offset   = 0x474,
 };
 
 // clang-format on

--- a/kpayload/source/offsets/850.c
+++ b/kpayload/source/offsets/850.c
@@ -129,6 +129,10 @@ const struct kpayload_offsets offsets_850 PAYLOAD_RDATA = {
 
   // SceShellCore patches - disable screenshot block
   .disable_screenshot_patch        = 0x000CFCA6,
+
+  // Process structure offsets
+  .proc_p_comm_offset = 0x454,
+  .proc_path_offset   = 0x474,
 };
 
 // clang-format on

--- a/kpayload/source/offsets/852.c
+++ b/kpayload/source/offsets/852.c
@@ -129,6 +129,10 @@ const struct kpayload_offsets offsets_852 PAYLOAD_RDATA = {
 
   // SceShellCore patches - disable screenshot block
   .disable_screenshot_patch        = 0x000CFCA6,
+
+  // Process structure offsets
+  .proc_p_comm_offset = 0x454,
+  .proc_path_offset   = 0x474,
 };
 
 // clang-format on

--- a/kpayload/source/offsets/900.c
+++ b/kpayload/source/offsets/900.c
@@ -129,6 +129,10 @@ const struct kpayload_offsets offsets_900 PAYLOAD_RDATA = {
 
   // SceShellCore patches - disable screenshot block
   .disable_screenshot_patch        = 0x000D1866,
+
+  // Process structure offsets
+  .proc_p_comm_offset = 0x454,
+  .proc_path_offset   = 0x474,
 };
 
 // clang-format on

--- a/kpayload/source/offsets/903.c
+++ b/kpayload/source/offsets/903.c
@@ -129,6 +129,10 @@ const struct kpayload_offsets offsets_903 PAYLOAD_RDATA = {
 
   // SceShellCore patches - disable screenshot block
   .disable_screenshot_patch        = 0x000D1956,
+
+  // Process structure offsets
+  .proc_p_comm_offset = 0x454,
+  .proc_path_offset   = 0x474,
 };
 
 // clang-format on

--- a/kpayload/source/offsets/904.c
+++ b/kpayload/source/offsets/904.c
@@ -129,6 +129,10 @@ const struct kpayload_offsets offsets_904 PAYLOAD_RDATA = {
 
   // SceShellCore patches - disable screenshot block
   .disable_screenshot_patch        = 0x0038EE26,
+
+  // Process structure offsets
+  .proc_p_comm_offset = 0x454,
+  .proc_path_offset   = 0x474,
 };
 
 // clang-format on

--- a/kpayload/source/offsets/950.c
+++ b/kpayload/source/offsets/950.c
@@ -129,6 +129,10 @@ const struct kpayload_offsets offsets_950 PAYLOAD_RDATA = {
 
   // SceShellCore patches - disable screenshot block
   .disable_screenshot_patch        = 0x000CF686,
+
+  // Process structure offsets
+  .proc_p_comm_offset = 0x454,
+  .proc_path_offset   = 0x474,
 };
 
 // clang-format on

--- a/kpayload/source/offsets/951.c
+++ b/kpayload/source/offsets/951.c
@@ -129,6 +129,10 @@ const struct kpayload_offsets offsets_951 PAYLOAD_RDATA = {
 
   // SceShellCore patches - disable screenshot block
   .disable_screenshot_patch        = 0x000CF686,
+
+  // Process structure offsets
+  .proc_p_comm_offset = 0x454,
+  .proc_path_offset   = 0x474,
 };
 
 // clang-format on

--- a/kpayload/source/offsets/960.c
+++ b/kpayload/source/offsets/960.c
@@ -129,6 +129,10 @@ const struct kpayload_offsets offsets_960 PAYLOAD_RDATA = {
 
   // SceShellCore patches - disable screenshot block
   .disable_screenshot_patch        = 0x000CF776,
+
+  // Process structure offsets
+  .proc_p_comm_offset = 0x454,
+  .proc_path_offset   = 0x474,
 };
 
 // clang-format on

--- a/kpayload/source/patch.c
+++ b/kpayload/source/patch.c
@@ -8,7 +8,6 @@
 #include "sparse.h"
 
 extern uint16_t fw_version PAYLOAD_BSS;
-extern const struct kpayload_offsets *fw_offsets PAYLOAD_BSS;
 
 extern int (*proc_rwmem)(struct proc *p, struct uio *uio) PAYLOAD_BSS;
 extern struct vmspace *(*vmspace_acquire_ref)(struct proc *p)PAYLOAD_BSS;
@@ -48,7 +47,8 @@ PAYLOAD_CODE static struct proc *proc_find_by_name(const char *name) {
   p = *ALLPROC;
 
   do {
-    if (!memcmp(p->p_comm, name, strlen(name))) {
+    char *p_comm = proc_get_p_comm(p);
+    if (p_comm && strlen(p_comm) == strlen(name) && !memcmp(p_comm, name, strlen(name))) {
       return p;
     }
   } while ((p = p->p_forw));


### PR DESCRIPTION
Should enable support for firmwares with a different size/layout for it's proc structure.