### PR TITLE
Various tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-/.vscode/
+/.vscode/*
+!/.vscode/tasks.json
+!/.vscode/c_cpp_properties.json
 
 /installer/build/
 /installer/temp.t

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,131 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Build all",
+      "type": "shell",
+      "command": "bash build.sh",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "focus": true,
+        "clear": true
+      }
+    },
+    {
+      "label": "Build kpayload",
+      "type": "shell",
+      "command": "make",
+      "options": {
+        "cwd": "${workspaceFolder}/kpayload"
+      },
+      "group": "build",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "focus": true,
+        "clear": true
+      }
+    },
+    {
+      "label": "Build installer",
+      "type": "shell",
+      "command": "make",
+      "options": {
+        "cwd": "${workspaceFolder}/installer"
+      },
+      "group": "build",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "focus": true,
+        "clear": true
+      }
+    },
+    {
+      "label": "Cleanup Build",
+      "type": "shell",
+      "command": "bash clean.sh && rm -f ./installer/source/*.inc.c",
+      "group": "build",
+      "presentation": {
+        "reveal": "never",
+        "panel": "shared",
+        "close": true
+      }
+    },
+    {
+      "label": "Run clang-format",
+      "type": "shell",
+      "command": "find ./installer/source ./installer/include ./kpayload/source ./kpayload/include -type f -regex '.*\\.\\(c\\|cc\\|cpp\\|h\\|hpp\\)' -exec clang-format -style=file -i {} + || true",
+      "group": "test",
+      "presentation": {
+        "reveal": "never",
+        "panel": "shared",
+        "close": true
+      }
+    },
+    {
+      "label": "Run Flawfinder",
+      "type": "shell",
+      "command": "flawfinder ./installer/source > ./flawfinder_installer_source.log 2>&1 || true && flawfinder ./installer/include > ./flawfinder_installer_include.log 2>&1 || true && flawfinder ./kpayload/source > ./flawfinder_kpayload_source.log 2>&1 || true && flawfinder ./kpayload/include > ./flawfinder_kpayload_include.log 2>&1 || true",
+      "group": "test",
+      "presentation": {
+        "reveal": "never",
+        "panel": "shared",
+        "close": true
+      }
+    },
+    {
+      "label": "Run Cppcheck",
+      "type": "shell",
+      "command": "cppcheck --check-level=exhaustive ./installer/source > ./cppcheck_installer_source.log 2>&1 || true && cppcheck --check-level=exhaustive ./installer/include > ./cppcheck_installer_include.log 2>&1 || true && cppcheck --check-level=exhaustive ./kpayload/source > ./cppcheck_kpayload_source.log 2>&1 || true && cppcheck --check-level=exhaustive ./kpayload/include > ./cppcheck_kpayload_include.log 2>&1 || true",
+      "group": "test",
+      "presentation": {
+        "reveal": "never",
+        "panel": "shared",
+        "close": true
+      }
+    },
+    {
+      "label": "Run All Lint/Checks",
+      "dependsOrder": "sequence",
+      "dependsOn": [
+        "Run clang-format",
+        "Run Flawfinder",
+        "Run Cppcheck"
+      ],
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      },
+      "presentation": {
+        "reveal": "never",
+        "panel": "shared",
+        "close": true
+      }
+    },
+    {
+      "label": "Send payload",
+      "type": "shell",
+      "command": "nc -w 3 ${input:ps4ip} 9020 < hen.bin || true",
+      "group": "build",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "close": true
+      }
+    }
+  ],
+  "inputs": [
+    {
+      "id": "ps4ip",
+      "type": "promptString",
+      "description": "Enter the IP address of your PS4",
+      "default": "192.168.1.1"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,131 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Build all",
+      "type": "shell",
+      "command": "bash build.sh",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "focus": true,
+        "clear": true
+      }
+    },
+    {
+      "label": "Build kpayload",
+      "type": "shell",
+      "command": "make",
+      "options": {
+        "cwd": "${workspaceFolder}/kpayload"
+      },
+      "group": "build",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "focus": true,
+        "clear": true
+      }
+    },
+    {
+      "label": "Build installer",
+      "type": "shell",
+      "command": "make",
+      "options": {
+        "cwd": "${workspaceFolder}/installer"
+      },
+      "group": "build",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "focus": true,
+        "clear": true
+      }
+    },
+    {
+      "label": "Cleanup Build",
+      "type": "shell",
+      "command": "bash clean.sh && rm -f ./installer/source/*.inc.c",
+      "group": "build",
+      "presentation": {
+        "reveal": "never",
+        "panel": "shared",
+        "close": true
+      }
+    },
+    {
+      "label": "Run clang-format",
+      "type": "shell",
+      "command": "find ./installer/source ./installer/include ./kpayload/source ./kpayload/include -type f -regex '.*\\.\\(c\\|cc\\|cpp\\|h\\|hpp\\)' -exec clang-format -style=file -i {} + || true",
+      "group": "test",
+      "presentation": {
+        "reveal": "never",
+        "panel": "shared",
+        "close": true
+      }
+    },
+    {
+      "label": "Run Flawfinder",
+      "type": "shell",
+      "command": "flawfinder ./installer/source > ./flawfinder_installer_source.log 2>&1 || true && flawfinder ./installer/include > ./flawfinder_installer_include.log 2>&1 || true && flawfinder ./kpayload/source > ./flawfinder_kpayload_source.log 2>&1 || true && flawfinder ./kpayload/include > ./flawfinder_kpayload_include.log 2>&1 || true",
+      "group": "test",
+      "presentation": {
+        "reveal": "never",
+        "panel": "shared",
+        "close": true
+      }
+    },
+    {
+      "label": "Run Cppcheck",
+      "type": "shell",
+      "command": "cppcheck --check-level=exhaustive ./installer/source > ./cppcheck_installer_source.log 2>&1 || true && cppcheck --check-level=exhaustive ./installer/include > ./cppcheck_installer_include.log 2>&1 || true && cppcheck --check-level=exhaustive ./kpayload/source > ./cppcheck_kpayload_source.log 2>&1 || true && cppcheck --check-level=exhaustive ./kpayload/include > ./cppcheck_kpayload_include.log 2>&1 || true",
+      "group": "test",
+      "presentation": {
+        "reveal": "never",
+        "panel": "shared",
+        "close": true
+      }
+    },
+    {
+      "label": "Run All Lint/Checks",
+      "dependsOrder": "sequence",
+      "dependsOn": [
+        "Run clang-format",
+        "Run Flawfinder",
+        "Run Cppcheck"
+      ],
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      },
+      "presentation": {
+        "reveal": "never",
+        "panel": "shared",
+        "close": true
+      }
+    },
+    {
+      "label": "Send payload",
+      "type": "shell",
+      "command": "nc -w 3 ${input:ps4ip} 9020 < hen.bin || true",
+      "group": "build",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "close": true
+      }
+    }
+  ],
+  "inputs": [
+    {
+      "id": "ps4ip",
+      "type": "promptString",
+      "description": "Enter the IP address of your PS4",
+      "default": "192.168.1.1"
+    }
+  ]
+}

--- a/build.sh
+++ b/build.sh
@@ -9,16 +9,15 @@ if [ "$(id -u)" -eq 0 ] && grep -qi ubuntu /etc/os-release; then
   apt-get install -y --no-install-recommends ca-certificates curl unzip xxd
 fi
 
-cd kpayload
-make clean
+pushd kpayload > /dev/null
 make
-cd ..
+popd > /dev/null
 
 mkdir -p tmp
-cd tmp
+pushd tmp > /dev/null
 
 # known bundled plugins
-PRX_FILES="plugin_bootloader.prx plugin_loader.prx plugin_server.prx"
+PRX_FILES="plugin_bootloader.prx plugin_loader.prx plugin_mono.prx plugin_server.prx"
 
 SKIP_DOWNLOAD=false
 if [ -f plugins.zip ]; then
@@ -42,18 +41,17 @@ fi
 # need to use translation units to force rebuilds
 # including as headers doesn't do it
 for file in *.prx; do
-  echo $file
+  echo "${file}"
   xxd -i "$file" | sed 's/^unsigned /static const unsigned /' > "../installer/source/${file}.inc.c"
 done
 
-cd ..
+popd > /dev/null
 
 xxd -i "hen.ini" | sed 's/^unsigned /static const unsigned /' > "installer/source/hen.ini.inc.c"
 
-cd installer
-make clean
+pushd installer > /dev/null
 make
-cd ..
+popd > /dev/null
 
 rm -f hen.bin
 cp installer/installer.bin hen.bin

--- a/clean.sh
+++ b/clean.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
+set -e
 
-cd kpayload
+pushd kpayload > /dev/null
 make clean
-cd ..
+popd > /dev/null
 
 rm -rf tmp
 
-cd installer
+pushd installer > /dev/null
 make clean
-cd ..
+rm -f source/*.inc.c
+popd > /dev/null
 
 rm -f hen.bin

--- a/installer/source/config.c
+++ b/installer/source/config.c
@@ -19,7 +19,7 @@
 
 #define MATCH(n) strcmp(name, n) == 0
 
-void upload_ini(const char* path) {
+void upload_ini(const char *path) {
   write_blob(path, hen_ini, hen_ini_len);
 }
 
@@ -41,29 +41,30 @@ static void set_config_defaults(struct configuration *config) {
   // target_id is already zeroed by memset, which means no spoofing
 }
 
-// Helper function to validate and set boolean config values (0 or 1)
+// Helper function to validate and set boolean config values (0, false, 1, or true)
 static int set_bool_config(const char *name, const char *value, int *config_field, int default_value) {
-  if (strcmp(value, "0") == 0) {
+  if (strcmp(value, "0") == 0 || strcasecmp(value, "false") == 0) {
     *config_field = 0;
     return 1;
-  } else if (strcmp(value, "1") == 0) {
+  } else if (strcmp(value, "1") == 0 || strcasecmp(value, "true") == 0) {
     *config_field = 1;
     return 1;
-  } else {
-    printf_notification("ERROR: Invalid %s:\n    Must be 0 or 1", name);
-    *config_field = default_value;
-    return 1;
   }
+
+  printf_notification("ERROR: Invalid %s:\n    Must be 0 or 1 (false or true)", name);
+  *config_field = default_value;
+  return 1;
 }
 
 static int set_int_config(const char *name, const char *value, int *config_field, int default_value) {
   int parsed_v = 0;
-  if (sscanf(value, "%d", &parsed_v) != 1) {
-    printf_notification("ERROR: Malformed %s.\nSetting to default value of `%d`", name, default_value);
-    *config_field = default_value;
-  } else {
+  if (sscanf(value, "%d", &parsed_v) == 1) {
     *config_field = parsed_v;
+    return 1;
   }
+
+  printf_notification("ERROR: Malformed %s", name);
+  *config_field = default_value;
   return 1;
 }
 

--- a/installer/source/kpayloads.c
+++ b/installer/source/kpayloads.c
@@ -1567,7 +1567,7 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     // Fixes
     //   - [X] pppwn
 
-    // TODO: Unpatch extra bytes from copyin, copyout, and copinstr (pppwn)
+    // Unpatch extra bytes from copyin, copyout, and copinstr (pppwn)
     kmem = (uint8_t *)&kernel_ptr[0x002DE045];
     kmem[0] = 0xC7;
 

--- a/installer/source/main.c
+++ b/installer/source/main.c
@@ -24,9 +24,7 @@ static void set_target_id(char *tid) {
   int buffer_size = sizeof(buffer);
   switch (hex) {
   case 0:
-  {
     break;
-  }
   case 0x80:
     snprintf(buffer, buffer_size, "Diagnostic");
     break;
@@ -87,7 +85,6 @@ static void set_target_id(char *tid) {
     printf_notification("ERROR: Unable to spoof target ID");
     return;
   }
-
 }
 
 int _main(struct thread *td) {
@@ -136,7 +133,7 @@ int _main(struct thread *td) {
   const bool found_ver = found_version == 0;
   if (file_exists(HDD_INI_PATH) && (ver_match || found_ver)) {
     const char *reason = " unknown!";
-    if (ver_match)    {
+    if (ver_match) {
       reason = " out of date!";
     } else if (found_ver) {
       reason = " not found!";

--- a/kpayload/linker.x
+++ b/kpayload/linker.x
@@ -5,26 +5,49 @@ ENTRY(_start)
 
 PHDRS
 {
-	header_seg PT_LOAD;
-	code_seg PT_LOAD;
-	rdata_seg PT_LOAD;
-	data_seg PT_LOAD;
-	bss_seg PT_LOAD;
-	bad_rdata_seg PT_LOAD;
-	bad_data_seg PT_LOAD;
-	bad_bss_seg PT_LOAD;
+	payload_code_seg PT_LOAD FLAGS(5);  /* R+X */
+	payload_data_seg PT_LOAD FLAGS(6);  /* R+W */
+	bad_seg PT_LOAD FLAGS(6);           /* R+W */
 }
 
 SECTIONS
 {
 	. = 0;
-	.payload_header : { *(.payload_header) } : header_seg
-	.payload_code : { *(.payload_code) } : code_seg
-	.payload_data : { *(.payload_rdata .rodata*) } : rdata_seg
-	.payload_data : { *(.payload_data) } : data_seg
-	.payload_bss  : { *(.payload_bss) } : bss_seg
+	.payload_header : {
+		*(.payload_header)
+		. = ALIGN(8);
+	} : payload_code_seg
+
+	.payload_code : {
+		*(.payload_code)
+		. = ALIGN(8);
+	} : payload_code_seg
+
+	.payload_rdata : {
+		*(.payload_rdata .rodata*)
+		. = ALIGN(8);
+	} : payload_data_seg
+
+	.payload_data : {
+		*(.payload_data)
+		. = ALIGN(8);
+	} : payload_data_seg
+
+	.payload_bss : {
+		*(.payload_bss)
+		. = ALIGN(8);
+	} : payload_data_seg
+
 	. = 0x100000;
-	.data : { *(.data) } : bad_data_seg
-	.bss  : { *(.bss) } : bad_bss_seg
+	.data : {
+		*(.data)
+		. = ALIGN(8);
+	} : bad_seg
+
+	.bss : {
+		*(.bss)
+		. = ALIGN(8);
+	} : bad_seg
+
 	/DISCARD/ : { *(*) }
 }

--- a/kpayload/source/hooks.c
+++ b/kpayload/source/hooks.c
@@ -1,9 +1,10 @@
 // Most of this code has been taken from ps4debug
 // https://github.com/kruniak/ps4debug
 //
+
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <stdbool.h>
 
 #include "amd_helper.h"
 #include "elf_helper.h"
@@ -272,7 +273,7 @@ PAYLOAD_CODE int sys_dynlib_load_prx_hook(struct thread *td, struct dynlib_load_
   // https://github.com/OpenOrbis/mira-project/blob/d8cc5790f08f93267354c2370eb3879edba0aa98/kernel/src/Plugins/Substitute/Substitute.cpp#L1003
   const char *titleid = td->td_proc->titleid;
   const char *p = args->prx_path ? args->prx_path : "";
-  //printf("%s td_name %s titleid %s prx %s\n", __FUNCTION__, td->td_name, titleid, p);
+  // printf("%s td_name %s titleid %s prx %s\n", __FUNCTION__, td->td_name, titleid, p);
   const uint8_t jmp[] = {0xff, 0x25, 0x00, 0x00, 0x00, 0x00};
   if (strstr(p, "/app0/sce_module/libc.prx")) {
     const int handle_out = args->handle_out ? *args->handle_out : 0;
@@ -292,18 +293,14 @@ PAYLOAD_CODE int sys_dynlib_load_prx_hook(struct thread *td, struct dynlib_load_
   }
   const bool isPartyDaemon = strstr(td->td_name, "ScePartyDaemonMain") != NULL;
   const bool isShellUI = strstr(td->td_name, "SceShellUIMain") != NULL;
-  //printf("%d %d\n", isPartyDaemon, isShellUI);
-  if (strstr(p, "/common/lib/libSceSysmodule.sprx") && (isPartyDaemon || isShellUI))
-  {
+  // printf("%d %d\n", isPartyDaemon, isShellUI);
+  if (strstr(p, "/common/lib/libSceSysmodule.sprx") && (isPartyDaemon || isShellUI)) {
     // dummy process to load server prx into
     struct dynlib_load_prx_args my_args = {};
     int handle = 0;
-    if (isPartyDaemon)
-    {
+    if (isPartyDaemon) {
       my_args.prx_path = PRX_SERVER_PATH;
-    }
-    else if (isShellUI)
-    {
+    } else if (isShellUI) {
       my_args.prx_path = PRX_MONO_PATH;
     }
     my_args.handle_out = &handle;

--- a/kpayload/source/hooks.c
+++ b/kpayload/source/hooks.c
@@ -345,8 +345,8 @@ struct sys_jailbreak_filedesc {
 };
 
 PAYLOAD_CODE void *sys_jailbreak(struct thread *td) {
-  struct sys_jailbreak_ucred *cred = td->td_proc->p_ucred;
-  struct sys_jailbreak_filedesc *fd = td->td_proc->p_fd;
+  struct sys_jailbreak_ucred *cred = (struct sys_jailbreak_ucred *)td->td_proc->p_ucred;
+  struct sys_jailbreak_filedesc *fd = (struct sys_jailbreak_filedesc *)td->td_proc->p_fd;
 
   void *td_ucred = *(void **)(((char *)td) + 304); // p_ucred == td_ucred
 

--- a/kpayload/source/main.c
+++ b/kpayload/source/main.c
@@ -93,6 +93,7 @@ int (*sys_dynlib_dlsym)(void *param_1, void *param_2) PAYLOAD_BSS;
 extern void install_fself_hooks(void) PAYLOAD_CODE;
 extern void install_fpkg_hooks(void) PAYLOAD_CODE;
 extern void install_patches(void) PAYLOAD_CODE;
+extern void install_nobd_syscall_hooks(void) PAYLOAD_CODE;
 extern void install_syscall_hooks(void) PAYLOAD_CODE;
 extern void *get_syscall(uint64_t n) PAYLOAD_CODE;
 


### PR DESCRIPTION
- Run clang-format
- Allow true/false for boolean ini options
- Match set_*_config functions
- Adjust linker and makefile
    - No longer use GNU extensions, so don't declare that
    - Link only used sections and mark them properly (RX and RW vs RWX)
- Add generic `.vscode` files for tasks/intellisense
- Ran shellcheck on build.sh/clean.sh

This clears all current build warning (including compiler and linker warnings)