### PR TITLE
Delete old file on write

### DIFF
--- a/installer/source/common.c
+++ b/installer/source/common.c
@@ -11,6 +11,7 @@ void write_blob(const char *path, const void *blob, const size_t blobsz) {
     return;
   }
 
+  unlink(path);
   int fd = open(path, O_CREAT | O_RDWR, 0777);
   printf_debug("fd %s %d\n", path, fd);
   if (fd > 0) {

--- a/installer/source/common.c
+++ b/installer/source/common.c
@@ -11,7 +11,9 @@ void write_blob(const char *path, const void *blob, const size_t blobsz) {
     return;
   }
 
-  unlink(path);
+  if (file_exists(path)) {
+    unlink(path);
+  }
   int fd = open(path, O_CREAT | O_RDWR, 0777);
   printf_debug("fd %s %d\n", path, fd);
   if (fd > 0) {


### PR DESCRIPTION
When updating config files on old version, it doesn't get overwritten for some reason.