### PR TITLE
Readme: Redirect plugins to repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,9 @@
 ## Features
 - Current Supports 5.05 - 12.02
 - Homebrew Enabler
-- [Plugins System](https://github.com/Scene-Collective/ps4-hen-plugins)
+- Plugins System
   - Plugins are bundled into HEN, the `hen.bin` in this repository has plugins as of [latest](https://github.com/Scene-Collective/ps4-hen-plugins/releases/latest) tag.
-  - Patches ShellUI to allow more features.
-    - Features:
-      - More details at [`plugin_mono`](https://github.com/Scene-Collective/ps4-hen-plugins/blob/main/.github/README.md#plugin_mono) page
-  - Load PRX into `ScePartyDaemon`
-    - (Starts kernel log server on port 3232, based on [klogsrv](https://github.com/ps5-payload-dev/klogsrv))
-    - (Starts FTP server on port 2121, based on [ftpsrv](https://github.com/ps5-payload-dev/ftpsrv))
-      - **Note: No SELF decryption yet.**
-  - Load PRX into retail apps (on startup in CRT `_init_env`) (You can make your own, the bundled one only prints to TTY for now)
+  - More info at [ps4-hen-plugins](https://github.com/Scene-Collective/ps4-hen-plugins) page.
 - Jailbreak
 - Sandbox Escape
 - Debug Settings


### PR DESCRIPTION
Because it gets updated a lot haha, better to direct people to go to the repository for up to date info.