### PR TITLE
"Finish" FW Support

### DIFF
--- a/installer/source/kpayloads.c
+++ b/installer/source/kpayloads.c
@@ -375,7 +375,6 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
   writeCr0(cr0 & ~X86_CR0_WP);
 
   // TODO:
-  // 5.55, 5.56                   // ps4-ipv6-uaf
   // 6.00, 6.02, 6.20, 6.50, 6.51 // ps4-ipv6-uaf
   // 6.70, 6.71                   // ps4jb2, ps4-ipv6-uaf
   if (fw_version == 474) {
@@ -488,7 +487,7 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
 
     kmem = (uint8_t *)&kernel_ptr[0x001413A7];
     kmem[0] = 0x37;
-  } else if (fw_version >= 500 && fw_version <= 501) {
+  } else if (fw_version == 500 || fw_version == 501) {
     // Fixes
     //   - [X] PS4-5.05-Kernel-Exploit
     //   - [X] ps4-ipv6-uaf
@@ -708,7 +707,7 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
 
     kmem = (uint8_t *)&kernel_ptr[0x0013D623];
     kmem[0] = 0x37;
-  } else if (fw_version >= 505 && fw_version <= 507) {
+  } else if (fw_version == 505 || fw_version == 507) {
     // Fixes
     //   - [X] PS4-5.05-Kernel-Exploit
     //   - [X] ps4-ipv6-uaf
@@ -1022,7 +1021,7 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[6] = 0x48;
     kmem[7] = 0x8B;
 
-    kmem = (uint8_t *)&kernel_ptr[0x00400130];
+    kmem = (uint8_t *)&kernel_ptr[0x00400030];
     kmem[0] = 0x48;
     kmem[1] = 0x31;
     kmem[2] = 0xC0;
@@ -1037,6 +1036,226 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[0] = 0x37;
 
     kmem = (uint8_t *)&kernel_ptr[0x003C24DC];
+    kmem[0] = 0x37;
+  } else if (fw_version == 555) {
+    // Fixes
+    //   - [X] ps4-ipv6-uaf
+
+    // Remove extra patch from ps4-ipv-uaf that provides more crash info
+    // TODO: We need to double check this and make sure we don't clobber a
+    // patch we make in `install_patches()`
+    kmem = (uint8_t *)&kernel_ptr[0x0077FDE0];
+    kmem[0] = 0x55;
+
+    // ChendoChap's patches from pOOBs4
+    kmem = (uint8_t *)&kernel_ptr[0x00000AED]; // bcopy
+    kmem[0] = 0xEB;
+
+    kmem = (uint8_t *)&kernel_ptr[0x00405BCD]; // bzero
+    kmem[0] = 0xEB;
+
+    kmem = (uint8_t *)&kernel_ptr[0x00405C11]; // pagezero
+    kmem[0] = 0xEB;
+
+    kmem = (uint8_t *)&kernel_ptr[0x00405C8D]; // memcpy
+    kmem[0] = 0xEB;
+
+    kmem = (uint8_t *)&kernel_ptr[0x00405CD1]; // pagecopy
+    kmem[0] = 0xEB;
+
+    kmem = (uint8_t *)&kernel_ptr[0x00405E7D]; // copyin
+    kmem[0] = 0xEB;
+
+    kmem = (uint8_t *)&kernel_ptr[0x0040632D]; // copyinstr
+    kmem[0] = 0xEB;
+
+    kmem = (uint8_t *)&kernel_ptr[0x004063FD]; // copystr
+    kmem[0] = 0xEB;
+
+    // patch amd64_syscall() to allow calling syscalls everywhere
+    kmem = (uint8_t *)&kernel_ptr[0x00000490];
+    kmem[0] = 0x00;
+    kmem[1] = 0x00;
+    kmem[2] = 0x00;
+    kmem[3] = 0x00;
+
+    kmem = (uint8_t *)&kernel_ptr[0x000004C6];
+    kmem[0] = 0x90;
+    kmem[1] = 0xE9;
+
+    kmem = (uint8_t *)&kernel_ptr[0x000004BD];
+    kmem[0] = 0xEB;
+    kmem[1] = 0x00;
+
+    kmem = (uint8_t *)&kernel_ptr[0x000004B2];
+    kmem[0] = 0x48;
+    kmem[1] = 0x3B;
+    kmem[2] = 0x90;
+    kmem[3] = 0xE0;
+    kmem[4] = 0x00;
+    kmem[5] = 0x00;
+    kmem[6] = 0x00;
+    kmem[7] = 0xEB;
+    kmem[8] = 0x00;
+
+    // repair sys_setuid() from exploit
+    kmem = (uint8_t *)&kernel_ptr[0x000107C2];
+    kmem[0] = 0xE8;
+    kmem[1] = 0x39;
+    kmem[2] = 0x65;
+    kmem[3] = 0x3C;
+
+    // patch sys_setuid() to allow freely changing the effective user ID
+    kmem = (uint8_t *)&kernel_ptr[0x000107CD];
+    kmem[0] = 0xEB;
+
+    // patch vm_map_protect() (called by sys_mprotect()) to allow rwx mappings
+    kmem = (uint8_t *)&kernel_ptr[0x0002EE96];
+    kmem[0] = 0x38;
+    kmem[1] = 0xFA;
+    kmem[2] = 0x0F;
+    kmem[3] = 0x85;
+    kmem[4] = 0x00;
+    kmem[5] = 0x00;
+    kmem[6] = 0x00;
+    kmem[7] = 0x00;
+
+    // patch sys_dynlib_dlsym() to allow dynamic symbol resolution everywhere
+    kmem = (uint8_t *)&kernel_ptr[0x0006390A];
+    kmem[0] = 0x90;
+    kmem[1] = 0xE9;
+    kmem[2] = 0xC3;
+    kmem[3] = 0x01;
+    kmem[4] = 0x00;
+    kmem[5] = 0x00;
+    kmem[6] = 0x48;
+    kmem[7] = 0x8B;
+
+    kmem = (uint8_t *)&kernel_ptr[0x004003F0];
+    kmem[0] = 0x48;
+    kmem[1] = 0x31;
+    kmem[2] = 0xC0;
+    kmem[3] = 0xC3;
+    kmem[4] = 0x25;
+    kmem[5] = 0x00;
+    kmem[6] = 0x00;
+    kmem[7] = 0x00;
+
+    // patch sys_mmap() to allow rwx mappings
+    kmem = (uint8_t *)&kernel_ptr[0x003C2899];
+    kmem[0] = 0x37;
+
+    kmem = (uint8_t *)&kernel_ptr[0x003C289C];
+    kmem[0] = 0x37;
+  } else if (fw_version == 556) {
+    // Fixes
+    //   - [X] ps4-ipv6-uaf
+
+    // Remove extra patch from ps4-ipv-uaf that provides more crash info
+    // TODO: We need to double check this and make sure we don't clobber a
+    // patch we make in `install_patches()`
+    kmem = (uint8_t *)&kernel_ptr[0x00788780];
+    kmem[0] = 0x55;
+
+    // ChendoChap's patches from pOOBs4
+    kmem = (uint8_t *)&kernel_ptr[0x00000ADD]; // bcopy
+    kmem[0] = 0xEB;
+
+    kmem = (uint8_t *)&kernel_ptr[0x0011464D]; // bzero
+    kmem[0] = 0xEB;
+
+    kmem = (uint8_t *)&kernel_ptr[0x00114680]; // pagezero
+    kmem[0] = 0xEB;
+
+    kmem = (uint8_t *)&kernel_ptr[0x0011470D]; // memcpy
+    kmem[0] = 0xEB;
+
+    kmem = (uint8_t *)&kernel_ptr[0x00114751]; // pagecopy
+    kmem[0] = 0xEB;
+
+    kmem = (uint8_t *)&kernel_ptr[0x001148FD]; // copyin
+    kmem[0] = 0xEB;
+
+    kmem = (uint8_t *)&kernel_ptr[0x00114DAD]; // copyinstr
+    kmem[0] = 0xEB;
+
+    kmem = (uint8_t *)&kernel_ptr[0x00114E7D]; // copystr
+    kmem[0] = 0xEB;
+
+    // patch amd64_syscall() to allow calling syscalls everywhere
+    kmem = (uint8_t *)&kernel_ptr[0x00000490];
+    kmem[0] = 0x00;
+    kmem[1] = 0x00;
+    kmem[2] = 0x00;
+    kmem[3] = 0x00;
+
+    kmem = (uint8_t *)&kernel_ptr[0x000004C6];
+    kmem[0] = 0x90;
+    kmem[1] = 0xE9;
+
+    kmem = (uint8_t *)&kernel_ptr[0x000004BD];
+    kmem[0] = 0xEB;
+    kmem[1] = 0x00;
+
+    kmem = (uint8_t *)&kernel_ptr[0x000004B2];
+    kmem[0] = 0x48;
+    kmem[1] = 0x3B;
+    kmem[2] = 0x90;
+    kmem[3] = 0xE0;
+    kmem[4] = 0x00;
+    kmem[5] = 0x00;
+    kmem[6] = 0x00;
+    kmem[7] = 0xEB;
+    kmem[8] = 0x00;
+
+    // repair sys_setuid() from exploit
+    kmem = (uint8_t *)&kernel_ptr[0x000290E2];
+    kmem[0] = 0xE8;
+    kmem[1] = 0x69;
+    kmem[2] = 0x2B;
+    kmem[3] = 0x27;
+
+    // patch sys_setuid() to allow freely changing the effective user ID
+    kmem = (uint8_t *)&kernel_ptr[0x000290ED];
+    kmem[0] = 0xEB;
+
+    // patch vm_map_protect() (called by sys_mprotect()) to allow rwx mappings
+    kmem = (uint8_t *)&kernel_ptr[0x00352256];
+    kmem[0] = 0x38;
+    kmem[1] = 0xFA;
+    kmem[2] = 0x0F;
+    kmem[3] = 0x85;
+    kmem[4] = 0x00;
+    kmem[5] = 0x00;
+    kmem[6] = 0x00;
+    kmem[7] = 0x00;
+
+    // patch sys_dynlib_dlsym() to allow dynamic symbol resolution everywhere
+    kmem = (uint8_t *)&kernel_ptr[0x0027F65A];
+    kmem[0] = 0x90;
+    kmem[1] = 0xE9;
+    kmem[2] = 0xC3;
+    kmem[3] = 0x01;
+    kmem[4] = 0x00;
+    kmem[5] = 0x00;
+    kmem[6] = 0x48;
+    kmem[7] = 0x8B;
+
+    kmem = (uint8_t *)&kernel_ptr[0x0001A810];
+    kmem[0] = 0x48;
+    kmem[1] = 0x31;
+    kmem[2] = 0xC0;
+    kmem[3] = 0xC3;
+    kmem[4] = 0x25;
+    kmem[5] = 0x00;
+    kmem[6] = 0x00;
+    kmem[7] = 0x00;
+
+    // patch sys_mmap() to allow rwx mappings
+    kmem = (uint8_t *)&kernel_ptr[0x0024026D];
+    kmem[0] = 0x37;
+
+    kmem = (uint8_t *)&kernel_ptr[0x00240270];
     kmem[0] = 0x37;
   } else if (fw_version == 672) {
     // Fixes
@@ -1512,7 +1731,7 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
 
     kmem = (uint8_t *)&kernel_ptr[0x000FD03D];
     kmem[0] = 0x37;
-  } else if (fw_version >= 850 && fw_version <= 852) {
+  } else if (fw_version == 850 || fw_version == 852) {
     // Fixes
     //   - [X] pppwn
 
@@ -1709,7 +1928,7 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
 
     kmem = (uint8_t *)&kernel_ptr[0x0016632D];
     kmem[0] = 0x37;
-  } else if (fw_version >= 903 && fw_version <= 904) {
+  } else if (fw_version == 903 || fw_version == 904) {
     // Fixes
     //   - [X] pppwn
 
@@ -1905,7 +2124,7 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
 
     kmem = (uint8_t *)&kernel_ptr[0x00122D7D];
     kmem[0] = 0x37;
-  } else if (fw_version >= 1000 && fw_version <= 1001) {
+  } else if (fw_version == 1000 || fw_version == 1001) {
     // Fixes
     //   - [X] pppwn
 

--- a/installer/source/kpayloads.c
+++ b/installer/source/kpayloads.c
@@ -425,17 +425,17 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[1] = 0x00;
 
     kmem = (uint8_t *)&kernel_ptr[0x003DD4D1];
-    kmem[0] = 0x48;
+    kmem[0] = 0x48; // repair
     kmem[1] = 0x3B;
     kmem[2] = 0x90;
     kmem[3] = 0xE0;
     kmem[4] = 0x00;
     kmem[5] = 0x00;
     kmem[6] = 0x00;
-    kmem[7] = 0xEB;
+    kmem[7] = 0xEB; // jmp
     kmem[8] = 0x00;
 
-    // repair sys_setuid() from exploit
+    // "repair" sys_setuid() from the exploit
     kmem = (uint8_t *)&kernel_ptr[0x00113B73];
     kmem[0] = 0xE8;
     kmem[1] = 0xB8;
@@ -447,36 +447,34 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[0] = 0xEB;
 
     // patch vm_map_protect() (called by sys_mprotect()) to allow rwx mappings
-    kmem = (uint8_t *)&kernel_ptr[0x00397876];
-    kmem[0] = 0x38;
-    kmem[1] = 0xEA;
-    kmem[2] = 0x0F;
-    kmem[3] = 0x85;
+    // also "repair" the exploit's patch
+    kmem = (uint8_t *)&kernel_ptr[0x00397878];
+    kmem[0] = 0xEB; // jmp
+    kmem[1] = 0x04;
+    kmem[2] = 0x13; // repair
+    kmem[3] = 0x07;
     kmem[4] = 0x00;
     kmem[5] = 0x00;
-    kmem[6] = 0x00;
-    kmem[7] = 0x00;
 
     // patch sys_dynlib_dlsym() to allow dynamic symbol resolution everywhere
     kmem = (uint8_t *)&kernel_ptr[0x003D05AE];
-    kmem[0] = 0x90;
+    kmem[0] = 0x90; // jmp
     kmem[1] = 0xE9;
-    kmem[2] = 0x51;
+    kmem[2] = 0x51; // repair
     kmem[3] = 0x03;
     kmem[4] = 0x00;
     kmem[5] = 0x00;
-    kmem[6] = 0x48;
-    kmem[7] = 0x8B;
 
     kmem = (uint8_t *)&kernel_ptr[0x000686A0];
-    kmem[0] = 0x48;
+    kmem[0] = 0x48; // ret 0
     kmem[1] = 0x31;
     kmem[2] = 0xC0;
     kmem[3] = 0xC3;
-    kmem[4] = 0x25;
-    kmem[5] = 0x00;
+    kmem[4] = 0x04; // repair
+    kmem[5] = 0x25;
     kmem[6] = 0x00;
     kmem[7] = 0x00;
+    kmem[8] = 0x00;
 
     // patch sys_mmap() to allow rwx mappings
     kmem = (uint8_t *)&kernel_ptr[0x001413A4];
@@ -535,17 +533,17 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[1] = 0x00;
 
     kmem = (uint8_t *)&kernel_ptr[0x000004B1];
-    kmem[0] = 0x48;
+    kmem[0] = 0x48; // repair
     kmem[1] = 0x3B;
     kmem[2] = 0x90;
     kmem[3] = 0xE0;
     kmem[4] = 0x00;
     kmem[5] = 0x00;
     kmem[6] = 0x00;
-    kmem[7] = 0xEB;
+    kmem[7] = 0xEB; // jmp
     kmem[8] = 0x00;
 
-    // repair sys_setuid() from exploit
+    // "repair" sys_setuid() from the exploit
     kmem = (uint8_t *)&kernel_ptr[0x00054A72];
     kmem[0] = 0xE8;
     kmem[1] = 0xA9;
@@ -557,36 +555,34 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[0] = 0xEB;
 
     // patch vm_map_protect() (called by sys_mprotect()) to allow rwx mappings
-    kmem = (uint8_t *)&kernel_ptr[0x001A3AF6];
-    kmem[0] = 0x38;
-    kmem[1] = 0xFA;
-    kmem[2] = 0x0F;
-    kmem[3] = 0x85;
+    // also "repair" the exploit's patch
+    kmem = (uint8_t *)&kernel_ptr[0x001A3AF8];
+    kmem[0] = 0xEB; // jmp
+    kmem[1] = 0x04;
+    kmem[2] = 0x8A; // repair
+    kmem[3] = 0x06;
     kmem[4] = 0x00;
     kmem[5] = 0x00;
-    kmem[6] = 0x00;
-    kmem[7] = 0x00;
 
     // patch sys_dynlib_dlsym() to allow dynamic symbol resolution everywhere
     kmem = (uint8_t *)&kernel_ptr[0x00237E2A];
-    kmem[0] = 0x90;
+    kmem[0] = 0x90; // jmp
     kmem[1] = 0xE9;
-    kmem[2] = 0xC0;
+    kmem[2] = 0xC0; // repair
     kmem[3] = 0x01;
     kmem[4] = 0x00;
     kmem[5] = 0x00;
-    kmem[6] = 0x48;
-    kmem[7] = 0x8B;
 
     kmem = (uint8_t *)&kernel_ptr[0x002B2350];
-    kmem[0] = 0x48;
+    kmem[0] = 0x48; // ret 0
     kmem[1] = 0x31;
     kmem[2] = 0xC0;
     kmem[3] = 0xC3;
-    kmem[4] = 0x25;
-    kmem[5] = 0x00;
+    kmem[4] = 0x04; // repair
+    kmem[5] = 0x25;
     kmem[6] = 0x00;
     kmem[7] = 0x00;
+    kmem[8] = 0x00;
 
     // patch sys_mmap() to allow rwx mappings
     kmem = (uint8_t *)&kernel_ptr[0x0013D510];
@@ -645,17 +641,17 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[1] = 0x00;
 
     kmem = (uint8_t *)&kernel_ptr[0x000004B1];
-    kmem[0] = 0x48;
+    kmem[0] = 0x48; // repair
     kmem[1] = 0x3B;
     kmem[2] = 0x90;
     kmem[3] = 0xE0;
     kmem[4] = 0x00;
     kmem[5] = 0x00;
     kmem[6] = 0x00;
-    kmem[7] = 0xEB;
+    kmem[7] = 0xEB; // jmp
     kmem[8] = 0x00;
 
-    // repair sys_setuid() from exploit
+    // "repair" sys_setuid() from the exploit
     kmem = (uint8_t *)&kernel_ptr[0x00054A72];
     kmem[0] = 0xE8;
     kmem[1] = 0x39;
@@ -667,36 +663,34 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[0] = 0xEB;
 
     // patch vm_map_protect() (called by sys_mprotect()) to allow rwx mappings
-    kmem = (uint8_t *)&kernel_ptr[0x001A3C06];
-    kmem[0] = 0x38;
-    kmem[1] = 0xFA;
-    kmem[2] = 0x0F;
-    kmem[3] = 0x85;
+    // also "repair" the exploit's patch
+    kmem = (uint8_t *)&kernel_ptr[0x001A3C08];
+    kmem[0] = 0xEB; // jmp
+    kmem[1] = 0x04;
+    kmem[2] = 0x8A; // repair
+    kmem[3] = 0x06;
     kmem[4] = 0x00;
     kmem[5] = 0x00;
-    kmem[6] = 0x00;
-    kmem[7] = 0x00;
 
     // patch sys_dynlib_dlsym() to allow dynamic symbol resolution everywhere
     kmem = (uint8_t *)&kernel_ptr[0x00237F3A];
-    kmem[0] = 0x90;
+    kmem[0] = 0x90; // jmp
     kmem[1] = 0xE9;
-    kmem[2] = 0xC0;
+    kmem[2] = 0xC0; // repair
     kmem[3] = 0x01;
     kmem[4] = 0x00;
     kmem[5] = 0x00;
-    kmem[6] = 0x48;
-    kmem[7] = 0x8B;
 
     kmem = (uint8_t *)&kernel_ptr[0x002B2620];
-    kmem[0] = 0x48;
+    kmem[0] = 0x48; // ret 0
     kmem[1] = 0x31;
     kmem[2] = 0xC0;
     kmem[3] = 0xC3;
-    kmem[4] = 0x25;
-    kmem[5] = 0x00;
+    kmem[4] = 0x04; // repair
+    kmem[5] = 0x25;
     kmem[6] = 0x00;
     kmem[7] = 0x00;
+    kmem[8] = 0x00;
 
     // patch sys_mmap() to allow rwx mappings
     kmem = (uint8_t *)&kernel_ptr[0x0013D620];
@@ -755,17 +749,17 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[1] = 0x00;
 
     kmem = (uint8_t *)&kernel_ptr[0x000004B1];
-    kmem[0] = 0x48;
+    kmem[0] = 0x48; // repair
     kmem[1] = 0x3B;
     kmem[2] = 0x90;
     kmem[3] = 0xE0;
     kmem[4] = 0x00;
     kmem[5] = 0x00;
     kmem[6] = 0x00;
-    kmem[7] = 0xEB;
+    kmem[7] = 0xEB; // jmp
     kmem[8] = 0x00;
 
-    // repair sys_setuid() from exploit
+    // "repair" sys_setuid() from the exploit
     kmem = (uint8_t *)&kernel_ptr[0x00054A72];
     kmem[0] = 0xE8;
     kmem[1] = 0x39;
@@ -777,36 +771,35 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[0] = 0xEB;
 
     // patch vm_map_protect() (called by sys_mprotect()) to allow rwx mappings
-    kmem = (uint8_t *)&kernel_ptr[0x001A3C06];
-    kmem[0] = 0x38;
-    kmem[1] = 0xFA;
-    kmem[2] = 0x0F;
-    kmem[3] = 0x85;
+    // also "repair" the exploit's patch
+    kmem = (uint8_t *)&kernel_ptr[0x001A3C08];
+    kmem[0] = 0xEB; // jmp
+    kmem[1] = 0x04;
+    kmem[2] = 0x8A; // repair
+    kmem[3] = 0x06;
     kmem[4] = 0x00;
     kmem[5] = 0x00;
-    kmem[6] = 0x00;
-    kmem[7] = 0x00;
 
     // patch sys_dynlib_dlsym() to allow dynamic symbol resolution everywhere
+    // also "repair" the exploit's patch
     kmem = (uint8_t *)&kernel_ptr[0x00237F3A];
-    kmem[0] = 0x90;
+    kmem[0] = 0x90; // jmp
     kmem[1] = 0xE9;
-    kmem[2] = 0xC0;
+    kmem[2] = 0xC0; // repair
     kmem[3] = 0x01;
     kmem[4] = 0x00;
     kmem[5] = 0x00;
-    kmem[6] = 0x48;
-    kmem[7] = 0x8B;
 
     kmem = (uint8_t *)&kernel_ptr[0x002B2620];
-    kmem[0] = 0x48;
+    kmem[0] = 0x48; // ret 0
     kmem[1] = 0x31;
     kmem[2] = 0xC0;
     kmem[3] = 0xC3;
-    kmem[4] = 0x25;
-    kmem[5] = 0x00;
+    kmem[4] = 0x04; // repair
+    kmem[5] = 0x25;
     kmem[6] = 0x00;
     kmem[7] = 0x00;
+    kmem[8] = 0x00;
 
     // patch sys_mmap() to allow rwx mappings
     kmem = (uint8_t *)&kernel_ptr[0x0013D620];
@@ -864,18 +857,11 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[0] = 0xEB;
     kmem[1] = 0x00;
 
-    kmem = (uint8_t *)&kernel_ptr[0x000004B2];
-    kmem[0] = 0x48;
-    kmem[1] = 0x3B;
-    kmem[2] = 0x90;
-    kmem[3] = 0xE0;
-    kmem[4] = 0x00;
-    kmem[5] = 0x00;
-    kmem[6] = 0x00;
-    kmem[7] = 0xEB;
-    kmem[8] = 0x00;
+    kmem = (uint8_t *)&kernel_ptr[0x000004B9];
+    kmem[0] = 0xEB;
+    kmem[1] = 0x00;
 
-    // repair sys_setuid() from exploit
+    // "repair" sys_setuid() from the exploit
     kmem = (uint8_t *)&kernel_ptr[0x000107C2];
     kmem[0] = 0xE8;
     kmem[1] = 0x79;
@@ -887,26 +873,19 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[0] = 0xEB;
 
     // patch vm_map_protect() (called by sys_mprotect()) to allow rwx mappings
-    kmem = (uint8_t *)&kernel_ptr[0x0002EE96];
-    kmem[0] = 0x38;
-    kmem[1] = 0xFA;
-    kmem[2] = 0x0F;
-    kmem[3] = 0x85;
+    // also "repair" the exploit's patch
+    kmem = (uint8_t *)&kernel_ptr[0x0002EE98];
+    kmem[0] = 0xEB; // jmp
+    kmem[1] = 0x04;
+    kmem[2] = 0x25; // repair
+    kmem[3] = 0x06;
     kmem[4] = 0x00;
     kmem[5] = 0x00;
-    kmem[6] = 0x00;
-    kmem[7] = 0x00;
 
     // patch sys_dynlib_dlsym() to allow dynamic symbol resolution everywhere
     kmem = (uint8_t *)&kernel_ptr[0x0006390A];
     kmem[0] = 0x90;
     kmem[1] = 0xE9;
-    kmem[2] = 0xC3;
-    kmem[3] = 0x01;
-    kmem[4] = 0x00;
-    kmem[5] = 0x00;
-    kmem[6] = 0x48;
-    kmem[7] = 0x8B;
 
     kmem = (uint8_t *)&kernel_ptr[0x00400130];
     kmem[0] = 0x48;
@@ -970,18 +949,11 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[0] = 0xEB;
     kmem[1] = 0x00;
 
-    kmem = (uint8_t *)&kernel_ptr[0x000004B2];
-    kmem[0] = 0x48;
-    kmem[1] = 0x3B;
-    kmem[2] = 0x90;
-    kmem[3] = 0xE0;
-    kmem[4] = 0x00;
-    kmem[5] = 0x00;
-    kmem[6] = 0x00;
-    kmem[7] = 0xEB;
-    kmem[8] = 0x00;
+    kmem = (uint8_t *)&kernel_ptr[0x000004B9];
+    kmem[0] = 0xEB;
+    kmem[1] = 0x00;
 
-    // repair sys_setuid() from exploit
+    // "repair" sys_setuid() from the exploit
     kmem = (uint8_t *)&kernel_ptr[0x000107C2];
     kmem[0] = 0xE8;
     kmem[1] = 0x79;
@@ -993,26 +965,19 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[0] = 0xEB;
 
     // patch vm_map_protect() (called by sys_mprotect()) to allow rwx mappings
-    kmem = (uint8_t *)&kernel_ptr[0x0002EE96];
-    kmem[0] = 0x38;
-    kmem[1] = 0xFA;
-    kmem[2] = 0x0F;
-    kmem[3] = 0x85;
+    // also "repair" the exploit's patch
+    kmem = (uint8_t *)&kernel_ptr[0x0002EE98];
+    kmem[0] = 0xEB; // jmp
+    kmem[1] = 0x04;
+    kmem[2] = 0x25; // repair
+    kmem[3] = 0x06;
     kmem[4] = 0x00;
     kmem[5] = 0x00;
-    kmem[6] = 0x00;
-    kmem[7] = 0x00;
 
     // patch sys_dynlib_dlsym() to allow dynamic symbol resolution everywhere
     kmem = (uint8_t *)&kernel_ptr[0x0006390A];
     kmem[0] = 0x90;
     kmem[1] = 0xE9;
-    kmem[2] = 0xC3;
-    kmem[3] = 0x01;
-    kmem[4] = 0x00;
-    kmem[5] = 0x00;
-    kmem[6] = 0x48;
-    kmem[7] = 0x8B;
 
     kmem = (uint8_t *)&kernel_ptr[0x00400030];
     kmem[0] = 0x48;
@@ -1076,18 +1041,11 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[0] = 0xEB;
     kmem[1] = 0x00;
 
-    kmem = (uint8_t *)&kernel_ptr[0x000004B2];
-    kmem[0] = 0x48;
-    kmem[1] = 0x3B;
-    kmem[2] = 0x90;
-    kmem[3] = 0xE0;
-    kmem[4] = 0x00;
-    kmem[5] = 0x00;
-    kmem[6] = 0x00;
-    kmem[7] = 0xEB;
-    kmem[8] = 0x00;
+    kmem = (uint8_t *)&kernel_ptr[0x000004B9];
+    kmem[0] = 0xEB;
+    kmem[1] = 0x00;
 
-    // repair sys_setuid() from exploit
+    // "repair" sys_setuid() from the exploit
     kmem = (uint8_t *)&kernel_ptr[0x000107C2];
     kmem[0] = 0xE8;
     kmem[1] = 0x39;
@@ -1099,26 +1057,19 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[0] = 0xEB;
 
     // patch vm_map_protect() (called by sys_mprotect()) to allow rwx mappings
-    kmem = (uint8_t *)&kernel_ptr[0x0002EE96];
-    kmem[0] = 0x38;
-    kmem[1] = 0xFA;
-    kmem[2] = 0x0F;
-    kmem[3] = 0x85;
+    // also "repair" the exploit's patch
+    kmem = (uint8_t *)&kernel_ptr[0x0002EE98];
+    kmem[0] = 0xEB; // jmp
+    kmem[1] = 0x04;
+    kmem[2] = 0x25; // repair
+    kmem[3] = 0x06;
     kmem[4] = 0x00;
     kmem[5] = 0x00;
-    kmem[6] = 0x00;
-    kmem[7] = 0x00;
 
     // patch sys_dynlib_dlsym() to allow dynamic symbol resolution everywhere
     kmem = (uint8_t *)&kernel_ptr[0x0006390A];
     kmem[0] = 0x90;
     kmem[1] = 0xE9;
-    kmem[2] = 0xC3;
-    kmem[3] = 0x01;
-    kmem[4] = 0x00;
-    kmem[5] = 0x00;
-    kmem[6] = 0x48;
-    kmem[7] = 0x8B;
 
     kmem = (uint8_t *)&kernel_ptr[0x004003F0];
     kmem[0] = 0x48;
@@ -1182,18 +1133,11 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[0] = 0xEB;
     kmem[1] = 0x00;
 
-    kmem = (uint8_t *)&kernel_ptr[0x000004B2];
-    kmem[0] = 0x48;
-    kmem[1] = 0x3B;
-    kmem[2] = 0x90;
-    kmem[3] = 0xE0;
-    kmem[4] = 0x00;
-    kmem[5] = 0x00;
-    kmem[6] = 0x00;
-    kmem[7] = 0xEB;
-    kmem[8] = 0x00;
+    kmem = (uint8_t *)&kernel_ptr[0x000004B9];
+    kmem[0] = 0xEB;
+    kmem[1] = 0x00;
 
-    // repair sys_setuid() from exploit
+    // "repair" sys_setuid() from the exploit
     kmem = (uint8_t *)&kernel_ptr[0x000290E2];
     kmem[0] = 0xE8;
     kmem[1] = 0x69;
@@ -1205,26 +1149,19 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[0] = 0xEB;
 
     // patch vm_map_protect() (called by sys_mprotect()) to allow rwx mappings
-    kmem = (uint8_t *)&kernel_ptr[0x00352256];
-    kmem[0] = 0x38;
-    kmem[1] = 0xFA;
-    kmem[2] = 0x0F;
-    kmem[3] = 0x85;
+    // also "repair" the exploit's patch
+    kmem = (uint8_t *)&kernel_ptr[0x00352258];
+    kmem[0] = 0xEB; // jmp
+    kmem[1] = 0x04;
+    kmem[2] = 0x95; // repair
+    kmem[3] = 0x06;
     kmem[4] = 0x00;
     kmem[5] = 0x00;
-    kmem[6] = 0x00;
-    kmem[7] = 0x00;
 
     // patch sys_dynlib_dlsym() to allow dynamic symbol resolution everywhere
     kmem = (uint8_t *)&kernel_ptr[0x0027F65A];
     kmem[0] = 0x90;
     kmem[1] = 0xE9;
-    kmem[2] = 0xC3;
-    kmem[3] = 0x01;
-    kmem[4] = 0x00;
-    kmem[5] = 0x00;
-    kmem[6] = 0x48;
-    kmem[7] = 0x8B;
 
     kmem = (uint8_t *)&kernel_ptr[0x0001A810];
     kmem[0] = 0x48;
@@ -1282,18 +1219,11 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[0] = 0xEB;
     kmem[1] = 0x00;
 
-    kmem = (uint8_t *)&kernel_ptr[0x000004B2];
-    kmem[0] = 0x48;
-    kmem[1] = 0x3B;
-    kmem[2] = 0x90;
-    kmem[3] = 0xE0;
-    kmem[4] = 0x00;
-    kmem[5] = 0x00;
-    kmem[6] = 0x00;
-    kmem[7] = 0xEB;
-    kmem[8] = 0x00;
+    kmem = (uint8_t *)&kernel_ptr[0x000004B9];
+    kmem[0] = 0xEB;
+    kmem[1] = 0x00;
 
-    // repair sys_setuid() from exploit
+    // "repair" sys_setuid() from the exploit
     kmem = (uint8_t *)&kernel_ptr[0x000290E2];
     kmem[0] = 0xE8;
     kmem[1] = 0x69;
@@ -1305,26 +1235,19 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[0] = 0xEB;
 
     // patch vm_map_protect() (called by sys_mprotect()) to allow rwx mappings
-    kmem = (uint8_t *)&kernel_ptr[0x00352256];
-    kmem[0] = 0x38;
-    kmem[1] = 0xEA;
-    kmem[2] = 0x0F;
-    kmem[3] = 0x85;
+    // also "repair" the exploit's patch
+    kmem = (uint8_t *)&kernel_ptr[0x00352258];
+    kmem[0] = 0xEB; // jmp
+    kmem[1] = 0x04;
+    kmem[2] = 0x95; // repair
+    kmem[3] = 0x06;
     kmem[4] = 0x00;
     kmem[5] = 0x00;
-    kmem[6] = 0x00;
-    kmem[7] = 0x00;
 
     // patch sys_dynlib_dlsym() to allow dynamic symbol resolution everywhere
     kmem = (uint8_t *)&kernel_ptr[0x0027F65A];
     kmem[0] = 0x90;
     kmem[1] = 0xE9;
-    kmem[2] = 0xC3;
-    kmem[3] = 0x01;
-    kmem[4] = 0x00;
-    kmem[5] = 0x00;
-    kmem[6] = 0x48;
-    kmem[7] = 0x8B;
 
     kmem = (uint8_t *)&kernel_ptr[0x0001A810];
     kmem[0] = 0x48;
@@ -1382,18 +1305,11 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[0] = 0xEB;
     kmem[1] = 0x00;
 
-    kmem = (uint8_t *)&kernel_ptr[0x000004B2];
-    kmem[0] = 0x48;
-    kmem[1] = 0x3B;
-    kmem[2] = 0x90;
-    kmem[3] = 0xE0;
-    kmem[4] = 0x00;
-    kmem[5] = 0x00;
-    kmem[6] = 0x00;
-    kmem[7] = 0xEB;
-    kmem[8] = 0x00;
+    kmem = (uint8_t *)&kernel_ptr[0x000004B9];
+    kmem[0] = 0xEB;
+    kmem[1] = 0x00;
 
-    // repair sys_setuid() from exploit
+    // "repair" sys_setuid() from the exploit
     kmem = (uint8_t *)&kernel_ptr[0x000290E2];
     kmem[0] = 0xE8;
     kmem[1] = 0x89;
@@ -1405,11 +1321,12 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[0] = 0xEB;
 
     // patch vm_map_protect() (called by sys_mprotect()) to allow rwx mappings
+    // also "repair" the exploit's patch
     kmem = (uint8_t *)&kernel_ptr[0x00352278];
-    kmem[0] = 0x0F;
-    kmem[1] = 0x85;
-    kmem[2] = 0x00;
-    kmem[3] = 0x00;
+    kmem[0] = 0xEB; // jmp
+    kmem[1] = 0x04;
+    kmem[2] = 0x95; // repair
+    kmem[3] = 0x06;
     kmem[4] = 0x00;
     kmem[5] = 0x00;
 
@@ -1417,10 +1334,6 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem = (uint8_t *)&kernel_ptr[0x0027F67A];
     kmem[0] = 0x90;
     kmem[1] = 0xE9;
-    kmem[2] = 0xC3;
-    kmem[3] = 0x01;
-    kmem[4] = 0x00;
-    kmem[5] = 0x00;
 
     kmem = (uint8_t *)&kernel_ptr[0x0001A810];
     kmem[0] = 0x48;
@@ -1487,34 +1400,29 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[0] = 0xEB;
     kmem[1] = 0x00;
 
-    kmem = (uint8_t *)&kernel_ptr[0x000004B2];
-    kmem[0] = 0x48;
-    kmem[1] = 0x3B;
-    kmem[2] = 0x90;
-    kmem[3] = 0xE8;
-    kmem[4] = 0x00;
-    kmem[5] = 0x00;
-    kmem[6] = 0x00;
-    kmem[7] = 0xEB;
-    kmem[8] = 0x00;
+    kmem = (uint8_t *)&kernel_ptr[0x000004B9];
+    kmem[0] = 0xEB;
+    kmem[1] = 0x00;
 
-    // patch sys_setuid() to allow freely changing the effective user ID
+    // "repair" sys_setuid() from the exploit
     kmem = (uint8_t *)&kernel_ptr[0x0010BB20];
     kmem[0] = 0xE8;
     kmem[1] = 0xBB;
     kmem[2] = 0x1B;
     kmem[3] = 0xFC;
     kmem[4] = 0xFF;
-    kmem[5] = 0x85;
-    kmem[6] = 0xC0;
-    kmem[7] = 0xEB;
+
+    // patch sys_setuid() to allow freely changing the effective user ID
+    kmem = (uint8_t *)&kernel_ptr[0x0010BB27];
+    kmem[0] = 0xEB;
 
     // patch vm_map_protect() (called by sys_mprotect()) to allow rwx mappings
+    // also "repair" the exploit's patch
     kmem = (uint8_t *)&kernel_ptr[0x00451A08];
-    kmem[0] = 0x0F;
-    kmem[1] = 0x85;
-    kmem[2] = 0x00;
-    kmem[3] = 0x00;
+    kmem[0] = 0xEB; // jmp
+    kmem[1] = 0x04;
+    kmem[2] = 0x68; // repair
+    kmem[3] = 0x06;
     kmem[4] = 0x00;
     kmem[5] = 0x00;
 
@@ -1527,10 +1435,6 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem = (uint8_t *)&kernel_ptr[0x001D85AA];
     kmem[0] = 0x90;
     kmem[1] = 0xE9;
-    kmem[2] = 0xC6;
-    kmem[3] = 0x01;
-    kmem[4] = 0x00;
-    kmem[5] = 0x00;
 
     kmem = (uint8_t *)&kernel_ptr[0x00419F20];
     kmem[0] = 0x48;
@@ -1598,34 +1502,36 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[0] = 0xEB;
     kmem[1] = 0x00;
 
+    // "repair" from the exploit
     kmem = (uint8_t *)&kernel_ptr[0x000004B2];
     kmem[0] = 0x48;
     kmem[1] = 0x3B;
     kmem[2] = 0x90;
     kmem[3] = 0xE8;
-    kmem[4] = 0x00;
-    kmem[5] = 0x00;
-    kmem[6] = 0x00;
-    kmem[7] = 0xEB;
-    kmem[8] = 0x00;
 
-    // patch sys_setuid() to allow freely changing the effective user ID
+    kmem = (uint8_t *)&kernel_ptr[0x000004B9];
+    kmem[0] = 0xEB;
+    kmem[1] = 0x00;
+
+    // "repair" sys_setuid() from the exploit
     kmem = (uint8_t *)&kernel_ptr[0x0010BED0];
     kmem[0] = 0xE8;
     kmem[1] = 0xBB;
     kmem[2] = 0x1B;
     kmem[3] = 0xFC;
     kmem[4] = 0xFF;
-    kmem[5] = 0x85;
-    kmem[6] = 0xC0;
-    kmem[7] = 0xEB;
+
+    // patch sys_setuid() to allow freely changing the effective user ID
+    kmem = (uint8_t *)&kernel_ptr[0x0010BED7];
+    kmem[0] = 0xEB;
 
     // patch vm_map_protect() (called by sys_mprotect()) to allow rwx mappings
+    // also "repair" the exploit's patch
     kmem = (uint8_t *)&kernel_ptr[0x00451DB8];
-    kmem[0] = 0x0F;
-    kmem[1] = 0x85;
-    kmem[2] = 0x00;
-    kmem[3] = 0x00;
+    kmem[0] = 0xEB; // jmp
+    kmem[1] = 0x04;
+    kmem[2] = 0x68; // repair
+    kmem[3] = 0x06;
     kmem[4] = 0x00;
     kmem[5] = 0x00;
 
@@ -1638,10 +1544,6 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem = (uint8_t *)&kernel_ptr[0x001D895A];
     kmem[0] = 0x90;
     kmem[1] = 0xE9;
-    kmem[2] = 0xC6;
-    kmem[3] = 0x01;
-    kmem[4] = 0x00;
-    kmem[5] = 0x00;
 
     kmem = (uint8_t *)&kernel_ptr[0x0041A2D0];
     kmem[0] = 0x48;
@@ -1661,7 +1563,7 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     //   - [X] ps4-ipv6-uaf
     //   - [X] pppwn
 
-    // Unpatch SysVeri
+    // Unpatch SysVeri from ps4-ipv6-uaf
     kmem = (uint8_t *)&kernel_ptr[0x0063A160];
     kmem[0] = 0x55;
 
@@ -1683,7 +1585,15 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[2] = 0x89;
     kmem[3] = 0xE5;
 
-    // Unpatch extra bytes from copyin, copyout, and copinstr (pppwn)
+    // Restore "extra" ps4jb2 patches
+    kmem = (uint8_t *)&kernel_ptr[0x0030F137];
+    kmem[0] = 0x74;
+
+    kmem = (uint8_t *)&kernel_ptr[0x0029EEC4];
+    kmem[0] = 0x15;
+    kmem[1] = 0x02;
+
+    // Restore extra bytes from copyin, copyout, and copinstr (pppwn)
     kmem = (uint8_t *)&kernel_ptr[0x0002F295];
     kmem[0] = 0xC7;
 
@@ -1742,33 +1652,35 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[0] = 0xEB;
     kmem[1] = 0x00;
 
+    // "repair" from the exploit
     kmem = (uint8_t *)&kernel_ptr[0x000004B2];
     kmem[0] = 0x48;
     kmem[1] = 0x3B;
     kmem[2] = 0x90;
     kmem[3] = 0xE8;
-    kmem[4] = 0x00;
-    kmem[5] = 0x00;
-    kmem[6] = 0x00;
-    kmem[7] = 0xEB;
-    kmem[8] = 0x00;
 
-    // patch sys_setuid() to allow freely changing the effective user ID
+    kmem = (uint8_t *)&kernel_ptr[0x000004B9];
+    kmem[0] = 0xEB;
+    kmem[1] = 0x00;
+
+    // "repair" sys_setuid() from the exploit
     kmem = (uint8_t *)&kernel_ptr[0x00087B70];
     kmem[0] = 0xE8;
     kmem[1] = 0x7B;
     kmem[2] = 0x12;
     kmem[3] = 0x03;
     kmem[4] = 0x00;
-    kmem[5] = 0x85;
-    kmem[6] = 0xC0;
-    kmem[7] = 0xEB;
+
+    // patch sys_setuid() to allow freely changing the effective user ID
+    kmem = (uint8_t *)&kernel_ptr[0x00087B77];
+    kmem[0] = 0xEB;
 
     // patch vm_map_protect() (called by sys_mprotect()) to allow rwx mappings
+    // also "repair" the exploit's patch
     kmem = (uint8_t *)&kernel_ptr[0x00264C08];
-    kmem[0] = 0x0F;
-    kmem[1] = 0x85;
-    kmem[2] = 0x00;
+    kmem[0] = 0xEB; // jmp
+    kmem[1] = 0x04;
+    kmem[2] = 0x00; // repair
     kmem[3] = 0x00;
     kmem[4] = 0x00;
     kmem[5] = 0x00;
@@ -1782,10 +1694,6 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem = (uint8_t *)&kernel_ptr[0x0009547B];
     kmem[0] = 0x90;
     kmem[1] = 0xE9;
-    kmem[2] = 0xBC;
-    kmem[3] = 0x01;
-    kmem[4] = 0x00;
-    kmem[5] = 0x00;
 
     kmem = (uint8_t *)&kernel_ptr[0x002F2C20];
     kmem[0] = 0x48;
@@ -1804,7 +1712,7 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     //   - [X] ps4jb2
     //   - [X] pppwn
 
-    // Unpatch extra bytes from copyin, copyout, and copinstr (pppwn)
+    // Restore extra bytes from copyin, copyout, and copinstr (pppwn)
     kmem = (uint8_t *)&kernel_ptr[0x0028FA55];
     kmem[0] = 0xC7;
 
@@ -1863,36 +1771,33 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[0] = 0xEB;
     kmem[1] = 0x00;
 
+    // "repair" from the exploit
     kmem = (uint8_t *)&kernel_ptr[0x000004B2];
     kmem[0] = 0x48;
     kmem[1] = 0x3B;
     kmem[2] = 0x90;
     kmem[3] = 0xE8;
-    kmem[4] = 0x00;
-    kmem[5] = 0x00;
-    kmem[6] = 0x00;
-    kmem[7] = 0xEB;
-    kmem[8] = 0x00;
 
-    // patch sys_setuid() to allow freely changing the effective user ID
+    kmem = (uint8_t *)&kernel_ptr[0x000004B9];
+    kmem[0] = 0xEB;
+    kmem[1] = 0x00;
+
+    // "repair" sys_setuid() from the exploit
     kmem = (uint8_t *)&kernel_ptr[0x0037A320];
     kmem[0] = 0xE8;
     kmem[1] = 0x8B;
     kmem[2] = 0x49;
     kmem[3] = 0x06;
     kmem[4] = 0x00;
-    kmem[5] = 0x85;
-    kmem[6] = 0xC0;
-    kmem[7] = 0xEB;
+
+    // patch sys_setuid() to allow freely changing the effective user ID
+    kmem = (uint8_t *)&kernel_ptr[0x0037A327];
+    kmem[0] = 0xEB;
 
     // patch vm_map_protect() (called by sys_mprotect()) to allow rwx mappings
     kmem = (uint8_t *)&kernel_ptr[0x003014C8];
-    kmem[0] = 0x0F;
-    kmem[1] = 0x85;
-    kmem[2] = 0x00;
-    kmem[3] = 0x00;
-    kmem[4] = 0x00;
-    kmem[5] = 0x00;
+    kmem[0] = 0xEB;
+    kmem[1] = 0x04;
 
     // TODO: Description of this patch. patch sys_dynlib_load_prx()
     kmem = (uint8_t *)&kernel_ptr[0x00451E04];
@@ -1903,10 +1808,6 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem = (uint8_t *)&kernel_ptr[0x004523C4];
     kmem[0] = 0x90;
     kmem[1] = 0xE9;
-    kmem[2] = 0xC7;
-    kmem[3] = 0x01;
-    kmem[4] = 0x00;
-    kmem[5] = 0x00;
 
     kmem = (uint8_t *)&kernel_ptr[0x00029A30];
     kmem[0] = 0x48;
@@ -1924,7 +1825,7 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     // Fixes
     //   - [X] pppwn
 
-    // Unpatch extra bytes from copyin, copyout, and copinstr (pppwn)
+    // Restore extra bytes from copyin, copyout, and copinstr (pppwn)
     kmem = (uint8_t *)&kernel_ptr[0x0025E415];
     kmem[0] = 0xC7;
 
@@ -1991,11 +1892,9 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[0] = 0xEB;
 
     // patch vm_map_protect() (called by sys_mprotect()) to allow rwx mappings
-    kmem = (uint8_t *)&kernel_ptr[0x003EC68D];
-    kmem[0] = 0x00;
-    kmem[1] = 0x00;
-    kmem[2] = 0x00;
-    kmem[3] = 0x00;
+    kmem = (uint8_t *)&kernel_ptr[0x003EC68B];
+    kmem[0] = 0xEB;
+    kmem[1] = 0x04;
 
     // TODO: Description of this patch. patch sys_dynlib_load_prx()
     kmem = (uint8_t *)&kernel_ptr[0x00318D84];
@@ -2022,7 +1921,7 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     // Fixes
     //   - [X] pppwn
 
-    // Unpatch extra bytes from copyin, copyout, and copinstr (pppwn)
+    // Restore extra bytes from copyin, copyout, and copinstr (pppwn)
     kmem = (uint8_t *)&kernel_ptr[0x003A4345];
     kmem[0] = 0xC7;
 
@@ -2089,11 +1988,9 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[0] = 0xEB;
 
     // patch vm_map_protect() (called by sys_mprotect()) to allow rwx mappings
-    kmem = (uint8_t *)&kernel_ptr[0x0014D6DD];
-    kmem[0] = 0x00;
-    kmem[1] = 0x00;
-    kmem[2] = 0x00;
-    kmem[3] = 0x00;
+    kmem = (uint8_t *)&kernel_ptr[0x0014D6DB];
+    kmem[0] = 0xEB;
+    kmem[1] = 0x04;
 
     // TODO: Description of this patch. patch sys_dynlib_load_prx()
     kmem = (uint8_t *)&kernel_ptr[0x00017474];
@@ -2121,7 +2018,7 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     //   - [X] pOOBs4
     //   - [X] pppwn
 
-    // Unpatch extra bytes from copyin, copyout, and copinstr (pppwn)
+    // Restore extra bytes from copyin, copyout, and copinstr (pppwn)
     kmem = (uint8_t *)&kernel_ptr[0x00271705];
     kmem[0] = 0xC7;
 
@@ -2188,11 +2085,9 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[0] = 0xEB;
 
     // patch vm_map_protect() (called by sys_mprotect()) to allow rwx mappings
-    kmem = (uint8_t *)&kernel_ptr[0x00080B8D];
-    kmem[0] = 0x00;
-    kmem[1] = 0x00;
-    kmem[2] = 0x00;
-    kmem[3] = 0x00;
+    kmem = (uint8_t *)&kernel_ptr[0x00080B8B];
+    kmem[0] = 0xEB;
+    kmem[1] = 0x04;
 
     // TODO: Description of this patch. patch sys_dynlib_load_prx()
     kmem = (uint8_t *)&kernel_ptr[0x0023AEC4];
@@ -2219,7 +2114,7 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     // Fixes
     //   - [X] pppwn
 
-    // Unpatch extra bytes from copyin, copyout, and copinstr (pppwn)
+    // Restore extra bytes from copyin, copyout, and copinstr (pppwn)
     kmem = (uint8_t *)&kernel_ptr[0x00271385];
     kmem[0] = 0xC7;
 
@@ -2286,11 +2181,9 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[0] = 0xEB;
 
     // patch vm_map_protect() (called by sys_mprotect()) to allow rwx mappings
-    kmem = (uint8_t *)&kernel_ptr[0x00080B8D];
-    kmem[0] = 0x00;
-    kmem[1] = 0x00;
-    kmem[2] = 0x00;
-    kmem[3] = 0x00;
+    kmem = (uint8_t *)&kernel_ptr[0x00080B8B];
+    kmem[0] = 0xEB;
+    kmem[1] = 0x04;
 
     // TODO: Description of this patch. patch sys_dynlib_load_prx()
     kmem = (uint8_t *)&kernel_ptr[0x0023AB94];
@@ -2317,7 +2210,7 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     // Fixes
     //   - [X] pppwn
 
-    // Unpatch extra bytes from copyin, copyout, and copinstr (pppwn)
+    // Restore extra bytes from copyin, copyout, and copinstr (pppwn)
     kmem = (uint8_t *)&kernel_ptr[0x00201F15];
     kmem[0] = 0xC7;
 
@@ -2384,11 +2277,9 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[0] = 0xEB;
 
     // patch vm_map_protect() (called by sys_mprotect()) to allow rwx mappings
-    kmem = (uint8_t *)&kernel_ptr[0x00196D3D];
-    kmem[0] = 0x00;
-    kmem[1] = 0x00;
-    kmem[2] = 0x00;
-    kmem[3] = 0x00;
+    kmem = (uint8_t *)&kernel_ptr[0x00196D3B];
+    kmem[0] = 0xEB;
+    kmem[1] = 0x04;
 
     // TODO: Description of this patch. patch sys_dynlib_load_prx()
     kmem = (uint8_t *)&kernel_ptr[0x0019F724];
@@ -2415,7 +2306,7 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     // Fixes
     //   - [X] pppwn
 
-    // Unpatch extra bytes from copyin, copyout, and copinstr (pppwn)
+    // Restore extra bytes from copyin, copyout, and copinstr (pppwn)
     kmem = (uint8_t *)&kernel_ptr[0x00472F75];
     kmem[0] = 0xC7;
 
@@ -2482,11 +2373,9 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[0] = 0xEB;
 
     // patch vm_map_protect() (called by sys_mprotect()) to allow rwx mappings
-    kmem = (uint8_t *)&kernel_ptr[0x0392070D];
-    kmem[0] = 0x00;
-    kmem[1] = 0x00;
-    kmem[2] = 0x00;
-    kmem[3] = 0x00;
+    kmem = (uint8_t *)&kernel_ptr[0x0392070B];
+    kmem[0] = 0xEB;
+    kmem[1] = 0x04;
 
     // TODO: Description of this patch. patch sys_dynlib_load_prx()
     kmem = (uint8_t *)&kernel_ptr[0x0018FAA4];
@@ -2513,7 +2402,7 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     // Fixes
     //   - [X] pppwn
 
-    // Unpatch extra bytes from copyin, copyout, and copinstr (pppwn)
+    // Restore extra bytes from copyin, copyout, and copinstr (pppwn)
     kmem = (uint8_t *)&kernel_ptr[0x000D75C5];
     kmem[0] = 0xC7;
 
@@ -2593,11 +2482,9 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[0] = 0xEB;
 
     // patch vm_map_protect() (called by sys_mprotect()) to allow rwx mappings
-    kmem = (uint8_t *)&kernel_ptr[0x0047B2EE];
-    kmem[0] = 0x00;
-    kmem[1] = 0x00;
-    kmem[2] = 0x00;
-    kmem[3] = 0x00;
+    kmem = (uint8_t *)&kernel_ptr[0x0047B2EC];
+    kmem[0] = 0xEB;
+    kmem[1] = 0x04;
 
     // TODO: Description of this patch. patch sys_dynlib_load_prx()
     kmem = (uint8_t *)&kernel_ptr[0x00212AD4];
@@ -2627,7 +2514,7 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     // Fixes
     //   - [X] pppwn
 
-    // Unpatch extra bytes from copyin, copyout, and copinstr (pppwn)
+    // Restore extra bytes from copyin, copyout, and copinstr (pppwn)
     kmem = (uint8_t *)&kernel_ptr[0x002DE045];
     kmem[0] = 0xC7;
 
@@ -2707,11 +2594,9 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[0] = 0xEB;
 
     // patch vm_map_protect() (called by sys_mprotect()) to allow rwx mappings
-    kmem = (uint8_t *)&kernel_ptr[0x0035C8EE];
-    kmem[0] = 0x00;
-    kmem[1] = 0x00;
-    kmem[2] = 0x00;
-    kmem[3] = 0x00;
+    kmem = (uint8_t *)&kernel_ptr[0x0035C8EC];
+    kmem[0] = 0xEB;
+    kmem[1] = 0x04;
 
     // TODO: Description of this patch. patch sys_dynlib_load_prx()
     kmem = (uint8_t *)&kernel_ptr[0x001E46F4];

--- a/installer/source/kpayloads.c
+++ b/installer/source/kpayloads.c
@@ -374,9 +374,6 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
   uint64_t cr0 = readCr0();
   writeCr0(cr0 & ~X86_CR0_WP);
 
-  // TODO:
-  // 6.00, 6.02, 6.20, 6.50, 6.51 // ps4-ipv6-uaf
-  // 6.70, 6.71                   // ps4jb2, ps4-ipv6-uaf
   if (fw_version == 474) {
     // Fixes
     //   - [X] PS4-5.05-Kernel-Exploit
@@ -916,10 +913,6 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[1] = 0x31;
     kmem[2] = 0xC0;
     kmem[3] = 0xC3;
-    kmem[4] = 0x25;
-    kmem[5] = 0x00;
-    kmem[6] = 0x00;
-    kmem[7] = 0x00;
 
     // patch sys_mmap() to allow rwx mappings
     kmem = (uint8_t *)&kernel_ptr[0x003C25D9];
@@ -1026,10 +1019,6 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[1] = 0x31;
     kmem[2] = 0xC0;
     kmem[3] = 0xC3;
-    kmem[4] = 0x25;
-    kmem[5] = 0x00;
-    kmem[6] = 0x00;
-    kmem[7] = 0x00;
 
     // patch sys_mmap() to allow rwx mappings
     kmem = (uint8_t *)&kernel_ptr[0x003C24D9];
@@ -1136,10 +1125,6 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[1] = 0x31;
     kmem[2] = 0xC0;
     kmem[3] = 0xC3;
-    kmem[4] = 0x25;
-    kmem[5] = 0x00;
-    kmem[6] = 0x00;
-    kmem[7] = 0x00;
 
     // patch sys_mmap() to allow rwx mappings
     kmem = (uint8_t *)&kernel_ptr[0x003C2899];
@@ -1164,7 +1149,7 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem = (uint8_t *)&kernel_ptr[0x0011464D]; // bzero
     kmem[0] = 0xEB;
 
-    kmem = (uint8_t *)&kernel_ptr[0x00114680]; // pagezero
+    kmem = (uint8_t *)&kernel_ptr[0x00114691]; // pagezero
     kmem[0] = 0xEB;
 
     kmem = (uint8_t *)&kernel_ptr[0x0011470D]; // memcpy
@@ -1246,10 +1231,6 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
     kmem[1] = 0x31;
     kmem[2] = 0xC0;
     kmem[3] = 0xC3;
-    kmem[4] = 0x25;
-    kmem[5] = 0x00;
-    kmem[6] = 0x00;
-    kmem[7] = 0x00;
 
     // patch sys_mmap() to allow rwx mappings
     kmem = (uint8_t *)&kernel_ptr[0x0024026D];
@@ -1257,7 +1238,313 @@ static int kpayload_exploit_fixes(struct thread *td, struct kpayload_firmware_ar
 
     kmem = (uint8_t *)&kernel_ptr[0x00240270];
     kmem[0] = 0x37;
-  } else if (fw_version == 672) {
+  } else if (fw_version == 600 || fw_version == 602) {
+    // Fixes
+    //   - [X] ps4-ipv6-uaf
+
+    // ChendoChap's patches from pOOBs4
+    kmem = (uint8_t *)&kernel_ptr[0x00000ADD]; // bcopy
+    kmem[0] = 0xEB;
+
+    kmem = (uint8_t *)&kernel_ptr[0x0011464D]; // bzero
+    kmem[0] = 0xEB;
+
+    kmem = (uint8_t *)&kernel_ptr[0x00114691]; // pagezero
+    kmem[0] = 0xEB;
+
+    kmem = (uint8_t *)&kernel_ptr[0x0011470D];// // memcpy
+    kmem[0] = 0xEB;
+
+    kmem = (uint8_t *)&kernel_ptr[0x00114751]; // pagecopy
+    kmem[0] = 0xEB;
+
+    kmem = (uint8_t *)&kernel_ptr[0x001148FD]; // copyin
+    kmem[0] = 0xEB;
+
+    kmem = (uint8_t *)&kernel_ptr[0x00114DAD]; // copyinstr
+    kmem[0] = 0xEB;
+
+    kmem = (uint8_t *)&kernel_ptr[0x00114E7D]; // copystr
+    kmem[0] = 0xEB;
+
+    // patch amd64_syscall() to allow calling syscalls everywhere
+    kmem = (uint8_t *)&kernel_ptr[0x00000490];
+    kmem[0] = 0x00;
+    kmem[1] = 0x00;
+    kmem[2] = 0x00;
+    kmem[3] = 0x00;
+
+    kmem = (uint8_t *)&kernel_ptr[0x000004C6];
+    kmem[0] = 0x90;
+    kmem[1] = 0xE9;
+
+    kmem = (uint8_t *)&kernel_ptr[0x000004BD];
+    kmem[0] = 0xEB;
+    kmem[1] = 0x00;
+
+    kmem = (uint8_t *)&kernel_ptr[0x000004B2];
+    kmem[0] = 0x48;
+    kmem[1] = 0x3B;
+    kmem[2] = 0x90;
+    kmem[3] = 0xE0;
+    kmem[4] = 0x00;
+    kmem[5] = 0x00;
+    kmem[6] = 0x00;
+    kmem[7] = 0xEB;
+    kmem[8] = 0x00;
+
+    // repair sys_setuid() from exploit
+    kmem = (uint8_t *)&kernel_ptr[0x000290E2];
+    kmem[0] = 0xE8;
+    kmem[1] = 0x69;
+    kmem[2] = 0x2B;
+    kmem[3] = 0x27;
+
+    // patch sys_setuid() to allow freely changing the effective user ID
+    kmem = (uint8_t *)&kernel_ptr[0x000290ED];
+    kmem[0] = 0xEB;
+
+    // patch vm_map_protect() (called by sys_mprotect()) to allow rwx mappings
+    kmem = (uint8_t *)&kernel_ptr[0x00352256];
+    kmem[0] = 0x38;
+    kmem[1] = 0xEA;
+    kmem[2] = 0x0F;
+    kmem[3] = 0x85;
+    kmem[4] = 0x00;
+    kmem[5] = 0x00;
+    kmem[6] = 0x00;
+    kmem[7] = 0x00;
+
+    // patch sys_dynlib_dlsym() to allow dynamic symbol resolution everywhere
+    kmem = (uint8_t *)&kernel_ptr[0x0027F65A];
+    kmem[0] = 0x90;
+    kmem[1] = 0xE9;
+    kmem[2] = 0xC3;
+    kmem[3] = 0x01;
+    kmem[4] = 0x00;
+    kmem[5] = 0x00;
+    kmem[6] = 0x48;
+    kmem[7] = 0x8B;
+
+    kmem = (uint8_t *)&kernel_ptr[0x0001A810];
+    kmem[0] = 0x48;
+    kmem[1] = 0x31;
+    kmem[2] = 0xC0;
+    kmem[3] = 0xC3;
+
+    // patch sys_mmap() to allow rwx mappings
+    kmem = (uint8_t *)&kernel_ptr[0x0024026D];
+    kmem[0] = 0x37;
+
+    kmem = (uint8_t *)&kernel_ptr[0x00240270];
+    kmem[0] = 0x37;
+  } else if (fw_version == 620) {
+    // Fixes
+    //   - [X] ps4-ipv6-uaf
+
+    // ChendoChap's patches from pOOBs4
+    kmem = (uint8_t *)&kernel_ptr[0x00000ADD]; // bcopy
+    kmem[0] = 0xEB;
+
+    kmem = (uint8_t *)&kernel_ptr[0x0011464D]; // bzero
+    kmem[0] = 0xEB;
+
+    kmem = (uint8_t *)&kernel_ptr[0x00114691]; // pagezero
+    kmem[0] = 0xEB;
+
+    kmem = (uint8_t *)&kernel_ptr[0x0011470D]; // memcpy
+    kmem[0] = 0xEB;
+
+    kmem = (uint8_t *)&kernel_ptr[0x00114751]; // pagecopy
+    kmem[0] = 0xEB;
+
+    kmem = (uint8_t *)&kernel_ptr[0x001148FD]; // copyin
+    kmem[0] = 0xEB;
+
+    kmem = (uint8_t *)&kernel_ptr[0x00114DAD]; // copyinstr
+    kmem[0] = 0xEB;
+
+    kmem = (uint8_t *)&kernel_ptr[0x00114E7D]; // copystr
+    kmem[0] = 0xEB;
+
+    // patch amd64_syscall() to allow calling syscalls everywhere
+    kmem = (uint8_t *)&kernel_ptr[0x00000490];
+    kmem[0] = 0x00;
+    kmem[1] = 0x00;
+    kmem[2] = 0x00;
+    kmem[3] = 0x00;
+
+    kmem = (uint8_t *)&kernel_ptr[0x000004C6];
+    kmem[0] = 0x90;
+    kmem[1] = 0xE9;
+
+    kmem = (uint8_t *)&kernel_ptr[0x000004BD];
+    kmem[0] = 0xEB;
+    kmem[1] = 0x00;
+
+    kmem = (uint8_t *)&kernel_ptr[0x000004B2];
+    kmem[0] = 0x48;
+    kmem[1] = 0x3B;
+    kmem[2] = 0x90;
+    kmem[3] = 0xE0;
+    kmem[4] = 0x00;
+    kmem[5] = 0x00;
+    kmem[6] = 0x00;
+    kmem[7] = 0xEB;
+    kmem[8] = 0x00;
+
+    // repair sys_setuid() from exploit
+    kmem = (uint8_t *)&kernel_ptr[0x000290E2];
+    kmem[0] = 0xE8;
+    kmem[1] = 0x89;
+    kmem[2] = 0x2B;
+    kmem[3] = 0x27;
+
+    // patch sys_setuid() to allow freely changing the effective user ID
+    kmem = (uint8_t *)&kernel_ptr[0x000290ED];
+    kmem[0] = 0xEB;
+
+    // patch vm_map_protect() (called by sys_mprotect()) to allow rwx mappings
+    kmem = (uint8_t *)&kernel_ptr[0x00352278];
+    kmem[0] = 0x0F;
+    kmem[1] = 0x85;
+    kmem[2] = 0x00;
+    kmem[3] = 0x00;
+    kmem[4] = 0x00;
+    kmem[5] = 0x00;
+
+    // patch sys_dynlib_dlsym() to allow dynamic symbol resolution everywhere
+    kmem = (uint8_t *)&kernel_ptr[0x0027F67A];
+    kmem[0] = 0x90;
+    kmem[1] = 0xE9;
+    kmem[2] = 0xC3;
+    kmem[3] = 0x01;
+    kmem[4] = 0x00;
+    kmem[5] = 0x00;
+
+    kmem = (uint8_t *)&kernel_ptr[0x0001A810];
+    kmem[0] = 0x48;
+    kmem[1] = 0x31;
+    kmem[2] = 0xC0;
+    kmem[3] = 0xC3;
+
+    // patch sys_mmap() to allow rwx mappings
+    kmem = (uint8_t *)&kernel_ptr[0x0024026D];
+    kmem[0] = 0x37;
+
+    kmem = (uint8_t *)&kernel_ptr[0x00240270];
+    kmem[0] = 0x37;
+  } else if (fw_version == 650 || fw_version == 651) {
+    // Fixes
+    //   - [X] ps4-ipv6-uaf
+
+    // ChendoChap's patches from pOOBs4
+    kmem = (uint8_t *)&kernel_ptr[0x0063C50E]; // veriPatch
+    kmem[0] = 0xEB;
+    kmem[1] = 0x00;
+
+    kmem = (uint8_t *)&kernel_ptr[0x00000ACD]; // bcopy
+    kmem[0] = 0xEB;
+
+    kmem = (uint8_t *)&kernel_ptr[0x003C114D]; // bzero
+    kmem[0] = 0xEB;
+
+    kmem = (uint8_t *)&kernel_ptr[0x003C1191]; // pagezero
+    kmem[0] = 0xEB;
+
+    kmem = (uint8_t *)&kernel_ptr[0x003C120D]; // memcpy
+    kmem[0] = 0xEB;
+
+    kmem = (uint8_t *)&kernel_ptr[0x003C1251]; // pagecopy
+    kmem[0] = 0xEB;
+
+    kmem = (uint8_t *)&kernel_ptr[0x003C13FD]; // copyin
+    kmem[0] = 0xEB;
+
+    kmem = (uint8_t *)&kernel_ptr[0x003C18AD]; // copyinstr
+    kmem[0] = 0xEB;
+
+    kmem = (uint8_t *)&kernel_ptr[0x003C197D]; // copystr
+    kmem[0] = 0xEB;
+
+    // stop sysVeri from causing a delayed panic on suspend
+    kmem = (uint8_t *)&kernel_ptr[0x0063CE0F];
+    kmem[0] = 0xEB;
+    kmem[1] = 0x00;
+
+    // patch amd64_syscall() to allow calling syscalls everywhere
+    kmem = (uint8_t *)&kernel_ptr[0x00000490];
+    kmem[0] = 0x00;
+    kmem[1] = 0x00;
+    kmem[2] = 0x00;
+    kmem[3] = 0x00;
+
+    kmem = (uint8_t *)&kernel_ptr[0x000004C6];
+    kmem[0] = 0x90;
+    kmem[1] = 0xE9;
+
+    kmem = (uint8_t *)&kernel_ptr[0x000004BD];
+    kmem[0] = 0xEB;
+    kmem[1] = 0x00;
+
+    kmem = (uint8_t *)&kernel_ptr[0x000004B2];
+    kmem[0] = 0x48;
+    kmem[1] = 0x3B;
+    kmem[2] = 0x90;
+    kmem[3] = 0xE8;
+    kmem[4] = 0x00;
+    kmem[5] = 0x00;
+    kmem[6] = 0x00;
+    kmem[7] = 0xEB;
+    kmem[8] = 0x00;
+
+    // patch sys_setuid() to allow freely changing the effective user ID
+    kmem = (uint8_t *)&kernel_ptr[0x0010BB20];
+    kmem[0] = 0xE8;
+    kmem[1] = 0xBB;
+    kmem[2] = 0x1B;
+    kmem[3] = 0xFC;
+    kmem[4] = 0xFF;
+    kmem[5] = 0x85;
+    kmem[6] = 0xC0;
+    kmem[7] = 0xEB;
+
+    // patch vm_map_protect() (called by sys_mprotect()) to allow rwx mappings
+    kmem = (uint8_t *)&kernel_ptr[0x00451A08];
+    kmem[0] = 0x0F;
+    kmem[1] = 0x85;
+    kmem[2] = 0x00;
+    kmem[3] = 0x00;
+    kmem[4] = 0x00;
+    kmem[5] = 0x00;
+
+    // TODO: Description of this patch. patch sys_dynlib_load_prx()
+    kmem = (uint8_t *)&kernel_ptr[0x001D801E];
+    kmem[0] = 0x90;
+    kmem[1] = 0xE9;
+
+    // patch sys_dynlib_dlsym() to allow dynamic symbol resolution everywhere
+    kmem = (uint8_t *)&kernel_ptr[0x001D85AA];
+    kmem[0] = 0x90;
+    kmem[1] = 0xE9;
+    kmem[2] = 0xC6;
+    kmem[3] = 0x01;
+    kmem[4] = 0x00;
+    kmem[5] = 0x00;
+
+    kmem = (uint8_t *)&kernel_ptr[0x00419F20];
+    kmem[0] = 0x48;
+    kmem[1] = 0x31;
+    kmem[2] = 0xC0;
+    kmem[3] = 0xC3;
+
+    // patch sys_mmap() to allow rwx mappings
+    kmem = (uint8_t *)&kernel_ptr[0x000AB57A];
+    kmem[0] = 0x37;
+
+    kmem = (uint8_t *)&kernel_ptr[0x000AB57D];
+    kmem[0] = 0x37;
+  } else if (fw_version >= 670 && fw_version <= 672) {
     // Fixes
     //   - [X] ps4jb2
     //   - [X] ps4-ipv6-uaf

--- a/kpayload/source/offsets/555.c
+++ b/kpayload/source/offsets/555.c
@@ -6,135 +6,135 @@
 
 const struct kpayload_offsets offsets_555 PAYLOAD_RDATA = {
   // data
-  .XFAST_SYSCALL_addr              = 0x0,
-  .PRISON0_addr                    = 0x0,
-  .ROOTVNODE_addr                  = 0x0,
-  .M_TEMP_addr                     = 0x0,
-  .MINI_SYSCORE_SELF_BINARY_addr   = 0x0,
-  .ALLPROC_addr                    = 0x0,
-  .SBL_DRIVER_MAPPED_PAGES_addr    = 0x0,
-  .SBL_PFS_SX_addr                 = 0x0,
-  .SBL_KEYMGR_KEY_SLOTS_addr       = 0x0,
-  .SBL_KEYMGR_KEY_RBTREE_addr      = 0x0,
-  .SBL_KEYMGR_BUF_VA_addr          = 0x0,
-  .SBL_KEYMGR_BUF_GVA_addr         = 0x0,
-  .FPU_CTX_addr                    = 0x0,
-  .SYSENT_addr                     = 0x0,
+  .XFAST_SYSCALL_addr              = 0x000001C0,
+  .PRISON0_addr                    = 0x01139180,
+  .ROOTVNODE_addr                  = 0x022F3570,
+  .M_TEMP_addr                     = 0x01A92FF0,
+  .MINI_SYSCORE_SELF_BINARY_addr   = 0x0156B618,
+  .ALLPROC_addr                    = 0x021910E8,
+  .SBL_DRIVER_MAPPED_PAGES_addr    = 0x026536C8,
+  .SBL_PFS_SX_addr                 = 0x02668080,
+  .SBL_KEYMGR_KEY_SLOTS_addr       = 0x0265B700,
+  .SBL_KEYMGR_KEY_RBTREE_addr      = 0x0265B710,
+  .SBL_KEYMGR_BUF_VA_addr          = 0x0265C000,
+  .SBL_KEYMGR_BUF_GVA_addr         = 0x0265C808,
+  .FPU_CTX_addr                    = 0x0266CD40,
+  .SYSENT_addr                     = 0x0111ACC0,
 
   // common
-  .memcmp_addr                     = 0x0,
-  ._sx_xlock_addr                  = 0x0,
-  ._sx_xunlock_addr                = 0x0,
-  .malloc_addr                     = 0x0,
-  .free_addr                       = 0x0,
-  .strstr_addr                     = 0x0,
-  .fpu_kern_enter_addr             = 0x0,
-  .fpu_kern_leave_addr             = 0x0,
-  .memcpy_addr                     = 0x0,
-  .memset_addr                     = 0x0,
-  .strlen_addr                     = 0x0,
-  .printf_addr                     = 0x0,
-  .eventhandler_register_addr      = 0x0,
+  .memcmp_addr                     = 0x0005E270,
+  ._sx_xlock_addr                  = 0x004828E0,
+  ._sx_xunlock_addr                = 0x00482AA0,
+  .malloc_addr                     = 0x00466DA0,
+  .free_addr                       = 0x00466FA0,
+  .strstr_addr                     = 0x000E4D90,
+  .fpu_kern_enter_addr             = 0x0022CC00,
+  .fpu_kern_leave_addr             = 0x0022CD00,
+  .memcpy_addr                     = 0x00405C80,
+  .memset_addr                     = 0x00108B50,
+  .strlen_addr                     = 0x002A6F30,
+  .printf_addr                     = 0x0011B150,
+  .eventhandler_register_addr      = 0x0022D6A0,
 
   // Fself
-  .sceSblACMgrGetPathId_addr       = 0x0,
-  .sceSblServiceMailbox_addr       = 0x0,
-  .sceSblAuthMgrSmIsLoadable2_addr = 0x0,
-  ._sceSblAuthMgrGetSelfInfo_addr  = 0x0,
-  ._sceSblAuthMgrSmStart_addr      = 0x0,
-  .sceSblAuthMgrVerifyHeader_addr  = 0x0,
+  .sceSblACMgrGetPathId_addr       = 0x001B4C30,
+  .sceSblServiceMailbox_addr       = 0x0064A6A0,
+  .sceSblAuthMgrSmIsLoadable2_addr = 0x0065C520,
+  ._sceSblAuthMgrGetSelfInfo_addr  = 0x0065CD80,
+  ._sceSblAuthMgrSmStart_addr      = 0x00657120,
+  .sceSblAuthMgrVerifyHeader_addr  = 0x0065C580,
 
   // Fpkg
-  .RsaesPkcs1v15Dec2048CRT_addr    = 0x0,
-  .Sha256Hmac_addr                 = 0x0,
-  .AesCbcCfb128Encrypt_addr        = 0x0,
-  .AesCbcCfb128Decrypt_addr        = 0x0,
-  .sceSblDriverSendMsg_0_addr      = 0x0,
-  .sceSblPfsSetKeys_addr           = 0x0,
-  .sceSblKeymgrSetKeyStorage_addr  = 0x0,
-  .sceSblKeymgrSetKeyForPfs_addr   = 0x0,
-  .sceSblKeymgrCleartKey_addr      = 0x0,
-  .sceSblKeymgrSmCallfunc_addr     = 0x0,
+  .RsaesPkcs1v15Dec2048CRT_addr    = 0x002EA6B0,
+  .Sha256Hmac_addr                 = 0x0031D470,
+  .AesCbcCfb128Encrypt_addr        = 0x0045ACE0,
+  .AesCbcCfb128Decrypt_addr        = 0x0045AF10,
+  .sceSblDriverSendMsg_0_addr      = 0x00635EA0,
+  .sceSblPfsSetKeys_addr           = 0x00641810,
+  .sceSblKeymgrSetKeyStorage_addr  = 0x0063C7C0,
+  .sceSblKeymgrSetKeyForPfs_addr   = 0x0063ED00,
+  .sceSblKeymgrCleartKey_addr      = 0x0063F080,
+  .sceSblKeymgrSmCallfunc_addr     = 0x0063E8D0,
 
   // Patch
-  .vmspace_acquire_ref_addr        = 0x0,
-  .vmspace_free_addr               = 0x0,
-  .vm_map_lock_read_addr           = 0x0,
-  .vm_map_unlock_read_addr         = 0x0,
-  .vm_map_lookup_entry_addr        = 0x0,
-  .proc_rwmem_addr                 = 0x0,
+  .vmspace_acquire_ref_addr        = 0x00029C90,
+  .vmspace_free_addr               = 0x00029AC0,
+  .vm_map_lock_read_addr           = 0x00029E40,
+  .vm_map_unlock_read_addr         = 0x00029E90,
+  .vm_map_lookup_entry_addr        = 0x0002A470,
+  .proc_rwmem_addr                 = 0x00393470,
 
   // Fself hooks
-  .sceSblAuthMgrIsLoadable__sceSblACMgrGetPathId_hook        = 0x0,
-  .sceSblAuthMgrIsLoadable2_hook                             = 0x0,
-  .sceSblAuthMgrVerifyHeader_hook1                           = 0x0,
-  .sceSblAuthMgrVerifyHeader_hook2                           = 0x0,
-  .sceSblAuthMgrSmLoadSelfSegment__sceSblServiceMailbox_hook = 0x0,
-  .sceSblAuthMgrSmLoadSelfBlock__sceSblServiceMailbox_hook   = 0x0,
+  .sceSblAuthMgrIsLoadable__sceSblACMgrGetPathId_hook        = 0x0065588D,
+  .sceSblAuthMgrIsLoadable2_hook                             = 0x006559D1,
+  .sceSblAuthMgrVerifyHeader_hook1                           = 0x0065612C,
+  .sceSblAuthMgrVerifyHeader_hook2                           = 0x00656DD8,
+  .sceSblAuthMgrSmLoadSelfSegment__sceSblServiceMailbox_hook = 0x00658D13,
+  .sceSblAuthMgrSmLoadSelfBlock__sceSblServiceMailbox_hook   = 0x00659966,
 
   // Fpkg hooks
-  .sceSblKeymgrSetKeyStorage__sceSblDriverSendMsg_hook       = 0x0,
-  .sceSblKeymgrInvalidateKey__sx_xlock_hook                  = 0x0,
-  .sceSblKeymgrSmCallfunc_npdrm_decrypt_isolated_rif_hook    = 0x0,
-  .sceSblKeymgrSmCallfunc_npdrm_decrypt_rif_new_hook         = 0x0,
-  .mountpfs__sceSblPfsSetKeys_hook1                          = 0x0,
-  .mountpfs__sceSblPfsSetKeys_hook2                          = 0x0,
+  .sceSblKeymgrSetKeyStorage__sceSblDriverSendMsg_hook       = 0x0063C865,
+  .sceSblKeymgrInvalidateKey__sx_xlock_hook                  = 0x0063FF2A,
+  .sceSblKeymgrSmCallfunc_npdrm_decrypt_isolated_rif_hook    = 0x00664130,
+  .sceSblKeymgrSmCallfunc_npdrm_decrypt_rif_new_hook         = 0x00664F13,
+  .mountpfs__sceSblPfsSetKeys_hook1                          = 0x006B1A68,
+  .mountpfs__sceSblPfsSetKeys_hook2                          = 0x006B1C97,
 
   // SceShellUI patches - debug patches - libkernel_sys.sprx
-  .sceSblRcMgrIsAllowDebugMenuForSettings_patch              = 0x0,
-  .sceSblRcMgrIsStoreMode_patch                              = 0x0,
+  .sceSblRcMgrIsAllowDebugMenuForSettings_patch              = 0x0001D4D0,
+  .sceSblRcMgrIsStoreMode_patch                              = 0x0001D830,
 
   // SceShellUI patches - remote play patches
-  .CreateUserForIDU_patch                                    = 0x0, // system_ex\app\NPXS20001\eboot.bin
-  .remote_play_menu_patch                                    = 0x0, // system_ex\app\NPXS20001\psm\Application\app.exe.sprx
+  .CreateUserForIDU_patch                                    = 0x001A3350, // system_ex\app\NPXS20001\eboot.bin
+  .remote_play_menu_patch                                    = 0x00E86151, // system_ex\app\NPXS20001\psm\Application\app.exe.sprx
 
   // SceRemotePlay patches - remote play patches - system\vsh\app\NPXS21006
-  .SceRemotePlay_patch1                                      = 0x0,
-  .SceRemotePlay_patch2                                      = 0x0,
+  .SceRemotePlay_patch1                                      = 0x0003C0B6,
+  .SceRemotePlay_patch2                                      = 0x0003C0D1,
 
   // SceShellCore patches - call sceKernelIsGenuineCEX
-  .sceKernelIsGenuineCEX_patch1    = 0x0,
-  .sceKernelIsGenuineCEX_patch2    = 0x0,
-  .sceKernelIsGenuineCEX_patch3    = 0x0,
-  .sceKernelIsGenuineCEX_patch4    = 0x0,
+  .sceKernelIsGenuineCEX_patch1    = 0x00177AFB,
+  .sceKernelIsGenuineCEX_patch2    = 0x007BA80B,
+  .sceKernelIsGenuineCEX_patch3    = 0x008052A3,
+  .sceKernelIsGenuineCEX_patch4    = 0x0099520B,
 
   // SceShellCore patches - call nidf_libSceDipsw
-  .nidf_libSceDipsw_patch1         = 0x0,
-  .nidf_libSceDipsw_patch2         = 0x0,
-  .nidf_libSceDipsw_patch3         = 0x0,
-  .nidf_libSceDipsw_patch4         = 0x0,
+  .nidf_libSceDipsw_patch1         = 0x00177B27,
+  .nidf_libSceDipsw_patch2         = 0x0024A9DD,
+  .nidf_libSceDipsw_patch3         = 0x007BA837,
+  .nidf_libSceDipsw_patch4         = 0x00995237,
 
   // SceShellCore patches - bypass firmware checks
-  .check_disc_root_param_patch     = 0x0,
-  .app_installer_patch             = 0x0,
-  .check_system_version            = 0x0,
-  .check_title_system_update_patch = 0x0,
+  .check_disc_root_param_patch     = 0x00139017,
+  .app_installer_patch             = 0x00139111,
+  .check_system_version            = 0x003CB269,
+  .check_title_system_update_patch = 0x003CDFC0,
 
   // SceShellCore patches - enable remote pkg installer
-  .enable_data_mount_patch         = 0x0,
+  .enable_data_mount_patch         = 0x00327C8A,
 
   // SceShellCore patches - enable VR without spoof
-  .enable_psvr_patch               = 0x0,
+  .enable_psvr_patch               = 0x00CE7790,
 
   // SceShellCore patches - enable fpkg
-  .enable_fpkg_patch               = 0x0,
+  .enable_fpkg_patch               = 0x003DE982,
 
   // SceShellCore patches - use `free` prefix instead `fake`
-  .fake_free_patch                 = 0x0,
+  .fake_free_patch                 = 0x00F196B0,
 
   // SceShellCore patches - enable official external HDD support
-  .pkg_installer_patch             = 0x0,
-  .ext_hdd_patch                   = 0x0,
+  .pkg_installer_patch             = 0x0097DB91,
+  .ext_hdd_patch                   = 0x0059CB5D,
 
   // SceShellCore patches - enable debug trophies
-  .debug_trophies_patch            = 0x0,
+  .debug_trophies_patch            = 0x006B9529,
 
   // SceShellCore patches - disable screenshot block
-  .disable_screenshot_patch        = 0x0,
+  .disable_screenshot_patch        = 0x000D47D6,
 
   // Process structure offsets
-  .proc_p_comm_offset = 0x44C,
-  .proc_path_offset   = 0x46C,
+  .proc_p_comm_offset = 0x454,
+  .proc_path_offset   = 0x474,
 };
 
 // clang-format on

--- a/kpayload/source/offsets/556.c
+++ b/kpayload/source/offsets/556.c
@@ -6,135 +6,135 @@
 
 const struct kpayload_offsets offsets_556 PAYLOAD_RDATA = {
   // data
-  .XFAST_SYSCALL_addr              = 0x0,
-  .PRISON0_addr                    = 0x0,
-  .ROOTVNODE_addr                  = 0x0,
-  .M_TEMP_addr                     = 0x0,
-  .MINI_SYSCORE_SELF_BINARY_addr   = 0x0,
-  .ALLPROC_addr                    = 0x0,
-  .SBL_DRIVER_MAPPED_PAGES_addr    = 0x0,
-  .SBL_PFS_SX_addr                 = 0x0,
-  .SBL_KEYMGR_KEY_SLOTS_addr       = 0x0,
-  .SBL_KEYMGR_KEY_RBTREE_addr      = 0x0,
-  .SBL_KEYMGR_BUF_VA_addr          = 0x0,
-  .SBL_KEYMGR_BUF_GVA_addr         = 0x0,
-  .FPU_CTX_addr                    = 0x0,
-  .SYSENT_addr                     = 0x0,
+  .XFAST_SYSCALL_addr              = 0x000001C0,
+  .PRISON0_addr                    = 0x01139458,
+  .ROOTVNODE_addr                  = 0x021BFAC0,
+  .M_TEMP_addr                     = 0x01559070,
+  .MINI_SYSCORE_SELF_BINARY_addr   = 0x0157B648,
+  .ALLPROC_addr                    = 0x022F7CD0,
+  .SBL_DRIVER_MAPPED_PAGES_addr    = 0x02655E58,
+  .SBL_PFS_SX_addr                 = 0x02673290,
+  .SBL_KEYMGR_KEY_SLOTS_addr       = 0x02680A78,
+  .SBL_KEYMGR_KEY_RBTREE_addr      = 0x02680A88,
+  .SBL_KEYMGR_BUF_VA_addr          = 0x02684000,
+  .SBL_KEYMGR_BUF_GVA_addr         = 0x02684808,
+  .FPU_CTX_addr                    = 0x0267D800,
+  .SYSENT_addr                     = 0x0111B540,
 
   // common
-  .memcmp_addr                     = 0x0,
-  ._sx_xlock_addr                  = 0x0,
-  ._sx_xunlock_addr                = 0x0,
-  .malloc_addr                     = 0x0,
-  .free_addr                       = 0x0,
-  .strstr_addr                     = 0x0,
-  .fpu_kern_enter_addr             = 0x0,
-  .fpu_kern_leave_addr             = 0x0,
-  .memcpy_addr                     = 0x0,
-  .memset_addr                     = 0x0,
-  .strlen_addr                     = 0x0,
-  .printf_addr                     = 0x0,
-  .eventhandler_register_addr      = 0x0,
+  .memcmp_addr                     = 0x004A1720,
+  ._sx_xlock_addr                  = 0x00083F00,
+  ._sx_xunlock_addr                = 0x000840C0,
+  .malloc_addr                     = 0x001D9060,
+  .free_addr                       = 0x001D9260,
+  .strstr_addr                     = 0x004247D0,
+  .fpu_kern_enter_addr             = 0x001E3990,
+  .fpu_kern_leave_addr             = 0x001E3A90,
+  .memcpy_addr                     = 0x00114700,
+  .memset_addr                     = 0x00394C40,
+  .strlen_addr                     = 0x000D5AA0,
+  .printf_addr                     = 0x00307DF0,
+  .eventhandler_register_addr      = 0x00180F80,
 
   // Fself
-  .sceSblACMgrGetPathId_addr       = 0x0,
-  .sceSblServiceMailbox_addr       = 0x0,
-  .sceSblAuthMgrSmIsLoadable2_addr = 0x0,
-  ._sceSblAuthMgrGetSelfInfo_addr  = 0x0,
-  ._sceSblAuthMgrSmStart_addr      = 0x0,
-  .sceSblAuthMgrVerifyHeader_addr  = 0x0,
+  .sceSblACMgrGetPathId_addr       = 0x004594C0,
+  .sceSblServiceMailbox_addr       = 0x0064AFC0,
+  .sceSblAuthMgrSmIsLoadable2_addr = 0x00656860,
+  ._sceSblAuthMgrGetSelfInfo_addr  = 0x006570F0,
+  ._sceSblAuthMgrSmStart_addr      = 0x0065ABB0,
+  .sceSblAuthMgrVerifyHeader_addr  = 0x006568C0,
 
   // Fpkg
-  .RsaesPkcs1v15Dec2048CRT_addr    = 0x0,
-  .Sha256Hmac_addr                 = 0x0,
-  .AesCbcCfb128Encrypt_addr        = 0x0,
-  .AesCbcCfb128Decrypt_addr        = 0x0,
-  .sceSblDriverSendMsg_0_addr      = 0x0,
-  .sceSblPfsSetKeys_addr           = 0x0,
-  .sceSblKeymgrSetKeyStorage_addr  = 0x0,
-  .sceSblKeymgrSetKeyForPfs_addr   = 0x0,
-  .sceSblKeymgrCleartKey_addr      = 0x0,
-  .sceSblKeymgrSmCallfunc_addr     = 0x0,
+  .RsaesPkcs1v15Dec2048CRT_addr    = 0x002209B0,
+  .Sha256Hmac_addr                 = 0x00165D80,
+  .AesCbcCfb128Encrypt_addr        = 0x002D40D0,
+  .AesCbcCfb128Decrypt_addr        = 0x002D4300,
+  .sceSblDriverSendMsg_0_addr      = 0x00637420,
+  .sceSblPfsSetKeys_addr           = 0x006407D0,
+  .sceSblKeymgrSetKeyStorage_addr  = 0x00645B90,
+  .sceSblKeymgrSetKeyForPfs_addr   = 0x00648A30,
+  .sceSblKeymgrCleartKey_addr      = 0x00648DC0,
+  .sceSblKeymgrSmCallfunc_addr     = 0x00648600,
 
   // Patch
-  .vmspace_acquire_ref_addr        = 0x0,
-  .vmspace_free_addr               = 0x0,
-  .vm_map_lock_read_addr           = 0x0,
-  .vm_map_unlock_read_addr         = 0x0,
-  .vm_map_lookup_entry_addr        = 0x0,
-  .proc_rwmem_addr                 = 0x0,
+  .vmspace_acquire_ref_addr        = 0x0034D090,
+  .vmspace_free_addr               = 0x0034CEC0,
+  .vm_map_lock_read_addr           = 0x0034D240,
+  .vm_map_unlock_read_addr         = 0x0034D290,
+  .vm_map_lookup_entry_addr        = 0x0034D840,
+  .proc_rwmem_addr                 = 0x0013E7A0,
 
   // Fself hooks
-  .sceSblAuthMgrIsLoadable__sceSblACMgrGetPathId_hook        = 0x0,
-  .sceSblAuthMgrIsLoadable2_hook                             = 0x0,
-  .sceSblAuthMgrVerifyHeader_hook1                           = 0x0,
-  .sceSblAuthMgrVerifyHeader_hook2                           = 0x0,
-  .sceSblAuthMgrSmLoadSelfSegment__sceSblServiceMailbox_hook = 0x0,
-  .sceSblAuthMgrSmLoadSelfBlock__sceSblServiceMailbox_hook   = 0x0,
+  .sceSblAuthMgrIsLoadable__sceSblACMgrGetPathId_hook        = 0x0065886C,
+  .sceSblAuthMgrIsLoadable2_hook                             = 0x006589BF,
+  .sceSblAuthMgrVerifyHeader_hook1                           = 0x00659176,
+  .sceSblAuthMgrVerifyHeader_hook2                           = 0x00659E18,
+  .sceSblAuthMgrSmLoadSelfSegment__sceSblServiceMailbox_hook = 0x0065CDDA,
+  .sceSblAuthMgrSmLoadSelfBlock__sceSblServiceMailbox_hook   = 0x0065DA21,
 
   // Fpkg hooks
-  .sceSblKeymgrSetKeyStorage__sceSblDriverSendMsg_hook       = 0x0,
-  .sceSblKeymgrInvalidateKey__sx_xlock_hook                  = 0x0,
-  .sceSblKeymgrSmCallfunc_npdrm_decrypt_isolated_rif_hook    = 0x0,
-  .sceSblKeymgrSmCallfunc_npdrm_decrypt_rif_new_hook         = 0x0,
-  .mountpfs__sceSblPfsSetKeys_hook1                          = 0x0,
-  .mountpfs__sceSblPfsSetKeys_hook2                          = 0x0,
+  .sceSblKeymgrSetKeyStorage__sceSblDriverSendMsg_hook       = 0x00645C35,
+  .sceSblKeymgrInvalidateKey__sx_xlock_hook                  = 0x00649C5D,
+  .sceSblKeymgrSmCallfunc_npdrm_decrypt_isolated_rif_hook    = 0x00668100,
+  .sceSblKeymgrSmCallfunc_npdrm_decrypt_rif_new_hook         = 0x00668F13,
+  .mountpfs__sceSblPfsSetKeys_hook1                          = 0x0069F5FA,
+  .mountpfs__sceSblPfsSetKeys_hook2                          = 0x0069F826,
 
   // SceShellUI patches - debug patches - libkernel_sys.sprx
-  .sceSblRcMgrIsAllowDebugMenuForSettings_patch              = 0x0,
-  .sceSblRcMgrIsStoreMode_patch                              = 0x0,
+  .sceSblRcMgrIsAllowDebugMenuForSettings_patch              = 0x0001D4D0,
+  .sceSblRcMgrIsStoreMode_patch                              = 0x0001D830,
 
   // SceShellUI patches - remote play patches
-  .CreateUserForIDU_patch                                    = 0x0, // system_ex\app\NPXS20001\eboot.bin
-  .remote_play_menu_patch                                    = 0x0, // system_ex\app\NPXS20001\psm\Application\app.exe.sprx
+  .CreateUserForIDU_patch                                    = 0x001A3350, // system_ex\app\NPXS20001\eboot.bin
+  .remote_play_menu_patch                                    = 0x00E86151, // system_ex\app\NPXS20001\psm\Application\app.exe.sprx
 
   // SceRemotePlay patches - remote play patches - system\vsh\app\NPXS21006
-  .SceRemotePlay_patch1                                      = 0x0,
-  .SceRemotePlay_patch2                                      = 0x0,
+  .SceRemotePlay_patch1                                      = 0x0003C0B6,
+  .SceRemotePlay_patch2                                      = 0x0003C0D1,
 
   // SceShellCore patches - call sceKernelIsGenuineCEX
-  .sceKernelIsGenuineCEX_patch1    = 0x0,
-  .sceKernelIsGenuineCEX_patch2    = 0x0,
-  .sceKernelIsGenuineCEX_patch3    = 0x0,
-  .sceKernelIsGenuineCEX_patch4    = 0x0,
+  .sceKernelIsGenuineCEX_patch1    = 0x001780FB,
+  .sceKernelIsGenuineCEX_patch2    = 0x007BB22B,
+  .sceKernelIsGenuineCEX_patch3    = 0x00805CC3,
+  .sceKernelIsGenuineCEX_patch4    = 0x00995C2B,
 
   // SceShellCore patches - call nidf_libSceDipsw
-  .nidf_libSceDipsw_patch1         = 0x0,
-  .nidf_libSceDipsw_patch2         = 0x0,
-  .nidf_libSceDipsw_patch3         = 0x0,
-  .nidf_libSceDipsw_patch4         = 0x0,
+  .nidf_libSceDipsw_patch1         = 0x00178127,
+  .nidf_libSceDipsw_patch2         = 0x0024AFDD,
+  .nidf_libSceDipsw_patch3         = 0x007BB257,
+  .nidf_libSceDipsw_patch4         = 0x00995C57,
 
   // SceShellCore patches - bypass firmware checks
-  .check_disc_root_param_patch     = 0x0,
-  .app_installer_patch             = 0x0,
-  .check_system_version            = 0x0,
-  .check_title_system_update_patch = 0x0,
+  .check_disc_root_param_patch     = 0x00139417,
+  .app_installer_patch             = 0x00139511,
+  .check_system_version            = 0x003CB869,
+  .check_title_system_update_patch = 0x003CE9E0,
 
   // SceShellCore patches - enable remote pkg installer
-  .enable_data_mount_patch         = 0x0,
+  .enable_data_mount_patch         = 0x0032828A,
 
   // SceShellCore patches - enable VR without spoof
-  .enable_psvr_patch               = 0x0,
+  .enable_psvr_patch               = 0x00CE81B0,
 
   // SceShellCore patches - enable fpkg
-  .enable_fpkg_patch               = 0x0,
+  .enable_fpkg_patch               = 0x003DF3A2,
 
   // SceShellCore patches - use `free` prefix instead `fake`
-  .fake_free_patch                 = 0x0,
+  .fake_free_patch                 = 0x00F1A0F0,
 
   // SceShellCore patches - enable official external HDD support
-  .pkg_installer_patch             = 0x0,
-  .ext_hdd_patch                   = 0x0,
+  .pkg_installer_patch             = 0x0097E5B1,
+  .ext_hdd_patch                   = 0x0059D57D,
 
   // SceShellCore patches - enable debug trophies
-  .debug_trophies_patch            = 0x0,
+  .debug_trophies_patch            = 0x006B9F49,
 
   // SceShellCore patches - disable screenshot block
-  .disable_screenshot_patch        = 0x0,
+  .disable_screenshot_patch        = 0x000D47D6,
 
   // Process structure offsets
-  .proc_p_comm_offset = 0x44C,
-  .proc_path_offset   = 0x46C,
+  .proc_p_comm_offset = 0x454,
+  .proc_path_offset   = 0x474,
 };
 
 // clang-format on

--- a/kpayload/source/offsets/600.c
+++ b/kpayload/source/offsets/600.c
@@ -6,135 +6,135 @@
 
 const struct kpayload_offsets offsets_600 PAYLOAD_RDATA = {
   // data
-  .XFAST_SYSCALL_addr              = 0x0,
-  .PRISON0_addr                    = 0x0,
-  .ROOTVNODE_addr                  = 0x0,
-  .M_TEMP_addr                     = 0x0,
-  .MINI_SYSCORE_SELF_BINARY_addr   = 0x0,
-  .ALLPROC_addr                    = 0x0,
-  .SBL_DRIVER_MAPPED_PAGES_addr    = 0x0,
-  .SBL_PFS_SX_addr                 = 0x0,
-  .SBL_KEYMGR_KEY_SLOTS_addr       = 0x0,
-  .SBL_KEYMGR_KEY_RBTREE_addr      = 0x0,
-  .SBL_KEYMGR_BUF_VA_addr          = 0x0,
-  .SBL_KEYMGR_BUF_GVA_addr         = 0x0,
-  .FPU_CTX_addr                    = 0x0,
-  .SYSENT_addr                     = 0x0,
+  .XFAST_SYSCALL_addr              = 0x000001C0,
+  .PRISON0_addr                    = 0x01139458,
+  .ROOTVNODE_addr                  = 0x021BFAC0,
+  .M_TEMP_addr                     = 0x01559070,
+  .MINI_SYSCORE_SELF_BINARY_addr   = 0x0157B648,
+  .ALLPROC_addr                    = 0x022F7CD0,
+  .SBL_DRIVER_MAPPED_PAGES_addr    = 0x02655E58,
+  .SBL_PFS_SX_addr                 = 0x02673290,
+  .SBL_KEYMGR_KEY_SLOTS_addr       = 0x02680A78,
+  .SBL_KEYMGR_KEY_RBTREE_addr      = 0x02680A88,
+  .SBL_KEYMGR_BUF_VA_addr          = 0x02684000,
+  .SBL_KEYMGR_BUF_GVA_addr         = 0x02684808,
+  .FPU_CTX_addr                    = 0x026806C0,
+  .SYSENT_addr                     = 0x0111B540,
 
   // common
-  .memcmp_addr                     = 0x0,
-  ._sx_xlock_addr                  = 0x0,
-  ._sx_xunlock_addr                = 0x0,
-  .malloc_addr                     = 0x0,
-  .free_addr                       = 0x0,
-  .strstr_addr                     = 0x0,
-  .fpu_kern_enter_addr             = 0x0,
-  .fpu_kern_leave_addr             = 0x0,
-  .memcpy_addr                     = 0x0,
-  .memset_addr                     = 0x0,
-  .strlen_addr                     = 0x0,
-  .printf_addr                     = 0x0,
-  .eventhandler_register_addr      = 0x0,
+  .memcmp_addr                     = 0x004A1720,
+  ._sx_xlock_addr                  = 0x00083F00,
+  ._sx_xunlock_addr                = 0x000840C0,
+  .malloc_addr                     = 0x001D9060,
+  .free_addr                       = 0x001D9260,
+  .strstr_addr                     = 0x004247F0,
+  .fpu_kern_enter_addr             = 0x001E3990,
+  .fpu_kern_leave_addr             = 0x001E3A90,
+  .memcpy_addr                     = 0x00114700,
+  .memset_addr                     = 0x00394C40,
+  .strlen_addr                     = 0x000D5AA0,
+  .printf_addr                     = 0x00307DF0,
+  .eventhandler_register_addr      = 0x00180F80,
 
   // Fself
-  .sceSblACMgrGetPathId_addr       = 0x0,
-  .sceSblServiceMailbox_addr       = 0x0,
-  .sceSblAuthMgrSmIsLoadable2_addr = 0x0,
-  ._sceSblAuthMgrGetSelfInfo_addr  = 0x0,
-  ._sceSblAuthMgrSmStart_addr      = 0x0,
-  .sceSblAuthMgrVerifyHeader_addr  = 0x0,
+  .sceSblACMgrGetPathId_addr       = 0x004594C0,
+  .sceSblServiceMailbox_addr       = 0x0064AFC0,
+  .sceSblAuthMgrSmIsLoadable2_addr = 0x00656860,
+  ._sceSblAuthMgrGetSelfInfo_addr  = 0x006570F0,
+  ._sceSblAuthMgrSmStart_addr      = 0x0065ABB0,
+  .sceSblAuthMgrVerifyHeader_addr  = 0x006568C0,
 
   // Fpkg
-  .RsaesPkcs1v15Dec2048CRT_addr    = 0x0,
-  .Sha256Hmac_addr                 = 0x0,
-  .AesCbcCfb128Encrypt_addr        = 0x0,
-  .AesCbcCfb128Decrypt_addr        = 0x0,
-  .sceSblDriverSendMsg_0_addr      = 0x0,
-  .sceSblPfsSetKeys_addr           = 0x0,
-  .sceSblKeymgrSetKeyStorage_addr  = 0x0,
-  .sceSblKeymgrSetKeyForPfs_addr   = 0x0,
-  .sceSblKeymgrCleartKey_addr      = 0x0,
-  .sceSblKeymgrSmCallfunc_addr     = 0x0,
+  .RsaesPkcs1v15Dec2048CRT_addr    = 0x002209B0,
+  .Sha256Hmac_addr                 = 0x00165D80,
+  .AesCbcCfb128Encrypt_addr        = 0x002D40D0,
+  .AesCbcCfb128Decrypt_addr        = 0x002D4300,
+  .sceSblDriverSendMsg_0_addr      = 0x00637420,
+  .sceSblPfsSetKeys_addr           = 0x006407D0,
+  .sceSblKeymgrSetKeyStorage_addr  = 0x00645B90,
+  .sceSblKeymgrSetKeyForPfs_addr   = 0x00648A30,
+  .sceSblKeymgrCleartKey_addr      = 0x00648DC0,
+  .sceSblKeymgrSmCallfunc_addr     = 0x00648600,
 
   // Patch
-  .vmspace_acquire_ref_addr        = 0x0,
-  .vmspace_free_addr               = 0x0,
-  .vm_map_lock_read_addr           = 0x0,
-  .vm_map_unlock_read_addr         = 0x0,
-  .vm_map_lookup_entry_addr        = 0x0,
-  .proc_rwmem_addr                 = 0x0,
+  .vmspace_acquire_ref_addr        = 0x0034D090,
+  .vmspace_free_addr               = 0x0034CEC0,
+  .vm_map_lock_read_addr           = 0x0034D240,
+  .vm_map_unlock_read_addr         = 0x0034D290,
+  .vm_map_lookup_entry_addr        = 0x0034D840,
+  .proc_rwmem_addr                 = 0x0013E7A0,
 
   // Fself hooks
-  .sceSblAuthMgrIsLoadable__sceSblACMgrGetPathId_hook        = 0x0,
-  .sceSblAuthMgrIsLoadable2_hook                             = 0x0,
-  .sceSblAuthMgrVerifyHeader_hook1                           = 0x0,
-  .sceSblAuthMgrVerifyHeader_hook2                           = 0x0,
-  .sceSblAuthMgrSmLoadSelfSegment__sceSblServiceMailbox_hook = 0x0,
-  .sceSblAuthMgrSmLoadSelfBlock__sceSblServiceMailbox_hook   = 0x0,
+  .sceSblAuthMgrIsLoadable__sceSblACMgrGetPathId_hook        = 0x0065886C,
+  .sceSblAuthMgrIsLoadable2_hook                             = 0x006589BF,
+  .sceSblAuthMgrVerifyHeader_hook1                           = 0x00659176,
+  .sceSblAuthMgrVerifyHeader_hook2                           = 0x00659E18,
+  .sceSblAuthMgrSmLoadSelfSegment__sceSblServiceMailbox_hook = 0x0065CDDA,
+  .sceSblAuthMgrSmLoadSelfBlock__sceSblServiceMailbox_hook   = 0x0065DA21,
 
   // Fpkg hooks
-  .sceSblKeymgrSetKeyStorage__sceSblDriverSendMsg_hook       = 0x0,
-  .sceSblKeymgrInvalidateKey__sx_xlock_hook                  = 0x0,
-  .sceSblKeymgrSmCallfunc_npdrm_decrypt_isolated_rif_hook    = 0x0,
-  .sceSblKeymgrSmCallfunc_npdrm_decrypt_rif_new_hook         = 0x0,
-  .mountpfs__sceSblPfsSetKeys_hook1                          = 0x0,
-  .mountpfs__sceSblPfsSetKeys_hook2                          = 0x0,
+  .sceSblKeymgrSetKeyStorage__sceSblDriverSendMsg_hook       = 0x00645C35,
+  .sceSblKeymgrInvalidateKey__sx_xlock_hook                  = 0x00649C5D,
+  .sceSblKeymgrSmCallfunc_npdrm_decrypt_isolated_rif_hook    = 0x00668100,
+  .sceSblKeymgrSmCallfunc_npdrm_decrypt_rif_new_hook         = 0x00668F13,
+  .mountpfs__sceSblPfsSetKeys_hook1                          = 0x0069F5FA,
+  .mountpfs__sceSblPfsSetKeys_hook2                          = 0x0069F826,
 
   // SceShellUI patches - debug patches - libkernel_sys.sprx
-  .sceSblRcMgrIsAllowDebugMenuForSettings_patch              = 0x0,
-  .sceSblRcMgrIsStoreMode_patch                              = 0x0,
+  .sceSblRcMgrIsAllowDebugMenuForSettings_patch              = 0x0001D6D0,
+  .sceSblRcMgrIsStoreMode_patch                              = 0x0001DA30,
 
   // SceShellUI patches - remote play patches
-  .CreateUserForIDU_patch                                    = 0x0, // system_ex\app\NPXS20001\eboot.bin
-  .remote_play_menu_patch                                    = 0x0, // system_ex\app\NPXS20001\psm\Application\app.exe.sprx
+  .CreateUserForIDU_patch                                    = 0x001A0510, // system_ex\app\NPXS20001\eboot.bin
+  .remote_play_menu_patch                                    = 0x00E9F4F1, // system_ex\app\NPXS20001\psm\Application\app.exe.sprx
 
   // SceRemotePlay patches - remote play patches - system\vsh\app\NPXS21006
-  .SceRemotePlay_patch1                                      = 0x0,
-  .SceRemotePlay_patch2                                      = 0x0,
+  .SceRemotePlay_patch1                                      = 0x0003CED6,
+  .SceRemotePlay_patch2                                      = 0x0003CEF1,
 
   // SceShellCore patches - call sceKernelIsGenuineCEX
-  .sceKernelIsGenuineCEX_patch1    = 0x0,
-  .sceKernelIsGenuineCEX_patch2    = 0x0,
-  .sceKernelIsGenuineCEX_patch3    = 0x0,
-  .sceKernelIsGenuineCEX_patch4    = 0x0,
+  .sceKernelIsGenuineCEX_patch1    = 0x00186170,
+  .sceKernelIsGenuineCEX_patch2    = 0x0081ED20,
+  .sceKernelIsGenuineCEX_patch3    = 0x00869BA3,
+  .sceKernelIsGenuineCEX_patch4    = 0x009F7550,
 
   // SceShellCore patches - call nidf_libSceDipsw
-  .nidf_libSceDipsw_patch1         = 0x0,
-  .nidf_libSceDipsw_patch2         = 0x0,
-  .nidf_libSceDipsw_patch3         = 0x0,
-  .nidf_libSceDipsw_patch4         = 0x0,
+  .nidf_libSceDipsw_patch1         = 0x0018619A,
+  .nidf_libSceDipsw_patch2         = 0x0025C923,
+  .nidf_libSceDipsw_patch3         = 0x0081ED4A,
+  .nidf_libSceDipsw_patch4         = 0x009F757A,
 
   // SceShellCore patches - bypass firmware checks
-  .check_disc_root_param_patch     = 0x0,
-  .app_installer_patch             = 0x0,
-  .check_system_version            = 0x0,
-  .check_title_system_update_patch = 0x0,
+  .check_disc_root_param_patch     = 0x00146642,
+  .app_installer_patch             = 0x00146731,
+  .check_system_version            = 0x003E3029,
+  .check_title_system_update_patch = 0x003E65D0,
 
   // SceShellCore patches - enable remote pkg installer
-  .enable_data_mount_patch         = 0x0,
+  .enable_data_mount_patch         = 0x0033FF4C,
 
   // SceShellCore patches - enable VR without spoof
-  .enable_psvr_patch               = 0x0,
+  .enable_psvr_patch               = 0x00DBBD40,
 
   // SceShellCore patches - enable fpkg
-  .enable_fpkg_patch               = 0x0,
+  .enable_fpkg_patch               = 0x003F7222,
 
   // SceShellCore patches - use `free` prefix instead `fake`
-  .fake_free_patch                 = 0x0,
+  .fake_free_patch                 = 0x00FA0CB1,
 
   // SceShellCore patches - enable official external HDD support
-  .pkg_installer_patch             = 0x0,
-  .ext_hdd_patch                   = 0x0,
+  .pkg_installer_patch             = 0x009E0031,
+  .ext_hdd_patch                   = 0x0060081D,
 
   // SceShellCore patches - enable debug trophies
-  .debug_trophies_patch            = 0x0,
+  .debug_trophies_patch            = 0x0071CDD9,
 
   // SceShellCore patches - disable screenshot block
-  .disable_screenshot_patch        = 0x0,
+  .disable_screenshot_patch        = 0x000DACD6,
 
   // Process structure offsets
-  .proc_p_comm_offset = 0x44C,
-  .proc_path_offset   = 0x46C,
+  .proc_p_comm_offset = 0x450,
+  .proc_path_offset   = 0x470,
 };
 
 // clang-format on

--- a/kpayload/source/offsets/602.c
+++ b/kpayload/source/offsets/602.c
@@ -6,135 +6,135 @@
 
 const struct kpayload_offsets offsets_602 PAYLOAD_RDATA = {
   // data
-  .XFAST_SYSCALL_addr              = 0x0,
-  .PRISON0_addr                    = 0x0,
-  .ROOTVNODE_addr                  = 0x0,
-  .M_TEMP_addr                     = 0x0,
-  .MINI_SYSCORE_SELF_BINARY_addr   = 0x0,
-  .ALLPROC_addr                    = 0x0,
-  .SBL_DRIVER_MAPPED_PAGES_addr    = 0x0,
-  .SBL_PFS_SX_addr                 = 0x0,
-  .SBL_KEYMGR_KEY_SLOTS_addr       = 0x0,
-  .SBL_KEYMGR_KEY_RBTREE_addr      = 0x0,
-  .SBL_KEYMGR_BUF_VA_addr          = 0x0,
-  .SBL_KEYMGR_BUF_GVA_addr         = 0x0,
-  .FPU_CTX_addr                    = 0x0,
-  .SYSENT_addr                     = 0x0,
+  .XFAST_SYSCALL_addr              = 0x000001C0,
+  .PRISON0_addr                    = 0x01139458,
+  .ROOTVNODE_addr                  = 0x021BFAC0,
+  .M_TEMP_addr                     = 0x01559070,
+  .MINI_SYSCORE_SELF_BINARY_addr   = 0x0157B648,
+  .ALLPROC_addr                    = 0x022F7CD0,
+  .SBL_DRIVER_MAPPED_PAGES_addr    = 0x02655E58,
+  .SBL_PFS_SX_addr                 = 0x02673290,
+  .SBL_KEYMGR_KEY_SLOTS_addr       = 0x02680A78,
+  .SBL_KEYMGR_KEY_RBTREE_addr      = 0x02680A88,
+  .SBL_KEYMGR_BUF_VA_addr          = 0x02684000,
+  .SBL_KEYMGR_BUF_GVA_addr         = 0x02684808,
+  .FPU_CTX_addr                    = 0x026806C0,
+  .SYSENT_addr                     = 0x0111B540,
 
   // common
-  .memcmp_addr                     = 0x0,
-  ._sx_xlock_addr                  = 0x0,
-  ._sx_xunlock_addr                = 0x0,
-  .malloc_addr                     = 0x0,
-  .free_addr                       = 0x0,
-  .strstr_addr                     = 0x0,
-  .fpu_kern_enter_addr             = 0x0,
-  .fpu_kern_leave_addr             = 0x0,
-  .memcpy_addr                     = 0x0,
-  .memset_addr                     = 0x0,
-  .strlen_addr                     = 0x0,
-  .printf_addr                     = 0x0,
-  .eventhandler_register_addr      = 0x0,
+  .memcmp_addr                     = 0x004A1720,
+  ._sx_xlock_addr                  = 0x00083F00,
+  ._sx_xunlock_addr                = 0x000840C0,
+  .malloc_addr                     = 0x001D9060,
+  .free_addr                       = 0x001D9260,
+  .strstr_addr                     = 0x004247F0,
+  .fpu_kern_enter_addr             = 0x001E3990,
+  .fpu_kern_leave_addr             = 0x001E3A90,
+  .memcpy_addr                     = 0x00114700,
+  .memset_addr                     = 0x00394C40,
+  .strlen_addr                     = 0x000D5AA0,
+  .printf_addr                     = 0x00307DF0,
+  .eventhandler_register_addr      = 0x00180F80,
 
   // Fself
-  .sceSblACMgrGetPathId_addr       = 0x0,
-  .sceSblServiceMailbox_addr       = 0x0,
-  .sceSblAuthMgrSmIsLoadable2_addr = 0x0,
-  ._sceSblAuthMgrGetSelfInfo_addr  = 0x0,
-  ._sceSblAuthMgrSmStart_addr      = 0x0,
-  .sceSblAuthMgrVerifyHeader_addr  = 0x0,
+  .sceSblACMgrGetPathId_addr       = 0x004594C0,
+  .sceSblServiceMailbox_addr       = 0x0064AFC0,
+  .sceSblAuthMgrSmIsLoadable2_addr = 0x00656860,
+  ._sceSblAuthMgrGetSelfInfo_addr  = 0x006570F0,
+  ._sceSblAuthMgrSmStart_addr      = 0x0065ABB0,
+  .sceSblAuthMgrVerifyHeader_addr  = 0x006568C0,
 
   // Fpkg
-  .RsaesPkcs1v15Dec2048CRT_addr    = 0x0,
-  .Sha256Hmac_addr                 = 0x0,
-  .AesCbcCfb128Encrypt_addr        = 0x0,
-  .AesCbcCfb128Decrypt_addr        = 0x0,
-  .sceSblDriverSendMsg_0_addr      = 0x0,
-  .sceSblPfsSetKeys_addr           = 0x0,
-  .sceSblKeymgrSetKeyStorage_addr  = 0x0,
-  .sceSblKeymgrSetKeyForPfs_addr   = 0x0,
-  .sceSblKeymgrCleartKey_addr      = 0x0,
-  .sceSblKeymgrSmCallfunc_addr     = 0x0,
+  .RsaesPkcs1v15Dec2048CRT_addr    = 0x002209B0,
+  .Sha256Hmac_addr                 = 0x00165D80,
+  .AesCbcCfb128Encrypt_addr        = 0x002D40D0,
+  .AesCbcCfb128Decrypt_addr        = 0x002D4300,
+  .sceSblDriverSendMsg_0_addr      = 0x00637420,
+  .sceSblPfsSetKeys_addr           = 0x006407D0,
+  .sceSblKeymgrSetKeyStorage_addr  = 0x00645B90,
+  .sceSblKeymgrSetKeyForPfs_addr   = 0x00648A30,
+  .sceSblKeymgrCleartKey_addr      = 0x00648DC0,
+  .sceSblKeymgrSmCallfunc_addr     = 0x00648600,
 
   // Patch
-  .vmspace_acquire_ref_addr        = 0x0,
-  .vmspace_free_addr               = 0x0,
-  .vm_map_lock_read_addr           = 0x0,
-  .vm_map_unlock_read_addr         = 0x0,
-  .vm_map_lookup_entry_addr        = 0x0,
-  .proc_rwmem_addr                 = 0x0,
+  .vmspace_acquire_ref_addr        = 0x0034D090,
+  .vmspace_free_addr               = 0x0034CEC0,
+  .vm_map_lock_read_addr           = 0x0034D240,
+  .vm_map_unlock_read_addr         = 0x0034D290,
+  .vm_map_lookup_entry_addr        = 0x0034D840,
+  .proc_rwmem_addr                 = 0x0013E7A0,
 
   // Fself hooks
-  .sceSblAuthMgrIsLoadable__sceSblACMgrGetPathId_hook        = 0x0,
-  .sceSblAuthMgrIsLoadable2_hook                             = 0x0,
-  .sceSblAuthMgrVerifyHeader_hook1                           = 0x0,
-  .sceSblAuthMgrVerifyHeader_hook2                           = 0x0,
-  .sceSblAuthMgrSmLoadSelfSegment__sceSblServiceMailbox_hook = 0x0,
-  .sceSblAuthMgrSmLoadSelfBlock__sceSblServiceMailbox_hook   = 0x0,
+  .sceSblAuthMgrIsLoadable__sceSblACMgrGetPathId_hook        = 0x0065886C,
+  .sceSblAuthMgrIsLoadable2_hook                             = 0x006589BF,
+  .sceSblAuthMgrVerifyHeader_hook1                           = 0x00659176,
+  .sceSblAuthMgrVerifyHeader_hook2                           = 0x00659E18,
+  .sceSblAuthMgrSmLoadSelfSegment__sceSblServiceMailbox_hook = 0x0065CDDA,
+  .sceSblAuthMgrSmLoadSelfBlock__sceSblServiceMailbox_hook   = 0x0065DA21,
 
   // Fpkg hooks
-  .sceSblKeymgrSetKeyStorage__sceSblDriverSendMsg_hook       = 0x0,
-  .sceSblKeymgrInvalidateKey__sx_xlock_hook                  = 0x0,
-  .sceSblKeymgrSmCallfunc_npdrm_decrypt_isolated_rif_hook    = 0x0,
-  .sceSblKeymgrSmCallfunc_npdrm_decrypt_rif_new_hook         = 0x0,
-  .mountpfs__sceSblPfsSetKeys_hook1                          = 0x0,
-  .mountpfs__sceSblPfsSetKeys_hook2                          = 0x0,
+  .sceSblKeymgrSetKeyStorage__sceSblDriverSendMsg_hook       = 0x00645C35,
+  .sceSblKeymgrInvalidateKey__sx_xlock_hook                  = 0x00649C5D,
+  .sceSblKeymgrSmCallfunc_npdrm_decrypt_isolated_rif_hook    = 0x00668100,
+  .sceSblKeymgrSmCallfunc_npdrm_decrypt_rif_new_hook         = 0x00668F13,
+  .mountpfs__sceSblPfsSetKeys_hook1                          = 0x0069F5FA,
+  .mountpfs__sceSblPfsSetKeys_hook2                          = 0x0069F826,
 
   // SceShellUI patches - debug patches - libkernel_sys.sprx
-  .sceSblRcMgrIsAllowDebugMenuForSettings_patch              = 0x0,
-  .sceSblRcMgrIsStoreMode_patch                              = 0x0,
+  .sceSblRcMgrIsAllowDebugMenuForSettings_patch              = 0x0001D6D0,
+  .sceSblRcMgrIsStoreMode_patch                              = 0x0001DA30,
 
   // SceShellUI patches - remote play patches
-  .CreateUserForIDU_patch                                    = 0x0, // system_ex\app\NPXS20001\eboot.bin
-  .remote_play_menu_patch                                    = 0x0, // system_ex\app\NPXS20001\psm\Application\app.exe.sprx
+  .CreateUserForIDU_patch                                    = 0x001A0510, // system_ex\app\NPXS20001\eboot.bin
+  .remote_play_menu_patch                                    = 0x00E9F4F1, // system_ex\app\NPXS20001\psm\Application\app.exe.sprx
 
   // SceRemotePlay patches - remote play patches - system\vsh\app\NPXS21006
-  .SceRemotePlay_patch1                                      = 0x0,
-  .SceRemotePlay_patch2                                      = 0x0,
+  .SceRemotePlay_patch1                                      = 0x0003CED6,
+  .SceRemotePlay_patch2                                      = 0x0003CEF1,
 
   // SceShellCore patches - call sceKernelIsGenuineCEX
-  .sceKernelIsGenuineCEX_patch1    = 0x0,
-  .sceKernelIsGenuineCEX_patch2    = 0x0,
-  .sceKernelIsGenuineCEX_patch3    = 0x0,
-  .sceKernelIsGenuineCEX_patch4    = 0x0,
+  .sceKernelIsGenuineCEX_patch1    = 0x00186170,
+  .sceKernelIsGenuineCEX_patch2    = 0x0081ED20,
+  .sceKernelIsGenuineCEX_patch3    = 0x00869BA3,
+  .sceKernelIsGenuineCEX_patch4    = 0x009F7550,
 
   // SceShellCore patches - call nidf_libSceDipsw
-  .nidf_libSceDipsw_patch1         = 0x0,
-  .nidf_libSceDipsw_patch2         = 0x0,
-  .nidf_libSceDipsw_patch3         = 0x0,
-  .nidf_libSceDipsw_patch4         = 0x0,
+  .nidf_libSceDipsw_patch1         = 0x0018619A,
+  .nidf_libSceDipsw_patch2         = 0x0025C923,
+  .nidf_libSceDipsw_patch3         = 0x0081ED4A,
+  .nidf_libSceDipsw_patch4         = 0x009F757A,
 
   // SceShellCore patches - bypass firmware checks
-  .check_disc_root_param_patch     = 0x0,
-  .app_installer_patch             = 0x0,
-  .check_system_version            = 0x0,
-  .check_title_system_update_patch = 0x0,
+  .check_disc_root_param_patch     = 0x00146642,
+  .app_installer_patch             = 0x00146731,
+  .check_system_version            = 0x003E3029,
+  .check_title_system_update_patch = 0x003E65D0,
 
   // SceShellCore patches - enable remote pkg installer
-  .enable_data_mount_patch         = 0x0,
+  .enable_data_mount_patch         = 0x0033FF4C,
 
   // SceShellCore patches - enable VR without spoof
-  .enable_psvr_patch               = 0x0,
+  .enable_psvr_patch               = 0x00DBBD40,
 
   // SceShellCore patches - enable fpkg
-  .enable_fpkg_patch               = 0x0,
+  .enable_fpkg_patch               = 0x003F7222,
 
   // SceShellCore patches - use `free` prefix instead `fake`
-  .fake_free_patch                 = 0x0,
+  .fake_free_patch                 = 0x00FA0CB1,
 
   // SceShellCore patches - enable official external HDD support
-  .pkg_installer_patch             = 0x0,
-  .ext_hdd_patch                   = 0x0,
+  .pkg_installer_patch             = 0x009E0031,
+  .ext_hdd_patch                   = 0x0060081D,
 
   // SceShellCore patches - enable debug trophies
-  .debug_trophies_patch            = 0x0,
+  .debug_trophies_patch            = 0x0071CDD9,
 
   // SceShellCore patches - disable screenshot block
-  .disable_screenshot_patch        = 0x0,
+  .disable_screenshot_patch        = 0x000DACD6,
 
   // Process structure offsets
-  .proc_p_comm_offset = 0x44C,
-  .proc_path_offset   = 0x46C,
+  .proc_p_comm_offset = 0x450,
+  .proc_path_offset   = 0x470,
 };
 
 // clang-format on

--- a/kpayload/source/offsets/620.c
+++ b/kpayload/source/offsets/620.c
@@ -6,135 +6,135 @@
 
 const struct kpayload_offsets offsets_620 PAYLOAD_RDATA = {
   // data
-  .XFAST_SYSCALL_addr              = 0x0,
-  .PRISON0_addr                    = 0x0,
-  .ROOTVNODE_addr                  = 0x0,
-  .M_TEMP_addr                     = 0x0,
-  .MINI_SYSCORE_SELF_BINARY_addr   = 0x0,
-  .ALLPROC_addr                    = 0x0,
-  .SBL_DRIVER_MAPPED_PAGES_addr    = 0x0,
-  .SBL_PFS_SX_addr                 = 0x0,
-  .SBL_KEYMGR_KEY_SLOTS_addr       = 0x0,
-  .SBL_KEYMGR_KEY_RBTREE_addr      = 0x0,
-  .SBL_KEYMGR_BUF_VA_addr          = 0x0,
-  .SBL_KEYMGR_BUF_GVA_addr         = 0x0,
-  .FPU_CTX_addr                    = 0x0,
-  .SYSENT_addr                     = 0x0,
+  .XFAST_SYSCALL_addr              = 0x000001C0,
+  .PRISON0_addr                    = 0x0113D458,
+  .ROOTVNODE_addr                  = 0x021C3AC0,
+  .M_TEMP_addr                     = 0x0155D070,
+  .MINI_SYSCORE_SELF_BINARY_addr   = 0x0157F648,
+  .ALLPROC_addr                    = 0x022FBCD0,
+  .SBL_DRIVER_MAPPED_PAGES_addr    = 0x02659E58,
+  .SBL_PFS_SX_addr                 = 0x02677290,
+  .SBL_KEYMGR_KEY_SLOTS_addr       = 0x02684A78,
+  .SBL_KEYMGR_KEY_RBTREE_addr      = 0x02684A88,
+  .SBL_KEYMGR_BUF_VA_addr          = 0x02688000,
+  .SBL_KEYMGR_BUF_GVA_addr         = 0x02688808,
+  .FPU_CTX_addr                    = 0x026846C0,
+  .SYSENT_addr                     = 0x0111F540,
 
   // common
-  .memcmp_addr                     = 0x0,
-  ._sx_xlock_addr                  = 0x0,
-  ._sx_xunlock_addr                = 0x0,
-  .malloc_addr                     = 0x0,
-  .free_addr                       = 0x0,
-  .strstr_addr                     = 0x0,
-  .fpu_kern_enter_addr             = 0x0,
-  .fpu_kern_leave_addr             = 0x0,
-  .memcpy_addr                     = 0x0,
-  .memset_addr                     = 0x0,
-  .strlen_addr                     = 0x0,
-  .printf_addr                     = 0x0,
-  .eventhandler_register_addr      = 0x0,
+  .memcmp_addr                     = 0x004A1740,
+  ._sx_xlock_addr                  = 0x00083F00,
+  ._sx_xunlock_addr                = 0x000840C0,
+  .malloc_addr                     = 0x001D9060,
+  .free_addr                       = 0x001D9260,
+  .strstr_addr                     = 0x004247F0,
+  .fpu_kern_enter_addr             = 0x001E3990,
+  .fpu_kern_leave_addr             = 0x001E3A90,
+  .memcpy_addr                     = 0x00114700,
+  .memset_addr                     = 0x00394C60,
+  .strlen_addr                     = 0x000D5AA0,
+  .printf_addr                     = 0x00307E10,
+  .eventhandler_register_addr      = 0x00180F80,
 
   // Fself
-  .sceSblACMgrGetPathId_addr       = 0x0,
-  .sceSblServiceMailbox_addr       = 0x0,
-  .sceSblAuthMgrSmIsLoadable2_addr = 0x0,
-  ._sceSblAuthMgrGetSelfInfo_addr  = 0x0,
-  ._sceSblAuthMgrSmStart_addr      = 0x0,
-  .sceSblAuthMgrVerifyHeader_addr  = 0x0,
+  .sceSblACMgrGetPathId_addr       = 0x004594E0,
+  .sceSblServiceMailbox_addr       = 0x0064B480,
+  .sceSblAuthMgrSmIsLoadable2_addr = 0x00656D20,
+  ._sceSblAuthMgrGetSelfInfo_addr  = 0x006575B0,
+  ._sceSblAuthMgrSmStart_addr      = 0x0065B070,
+  .sceSblAuthMgrVerifyHeader_addr  = 0x00656D80,
 
   // Fpkg
-  .RsaesPkcs1v15Dec2048CRT_addr    = 0x0,
-  .Sha256Hmac_addr                 = 0x0,
-  .AesCbcCfb128Encrypt_addr        = 0x0,
-  .AesCbcCfb128Decrypt_addr        = 0x0,
-  .sceSblDriverSendMsg_0_addr      = 0x0,
-  .sceSblPfsSetKeys_addr           = 0x0,
-  .sceSblKeymgrSetKeyStorage_addr  = 0x0,
-  .sceSblKeymgrSetKeyForPfs_addr   = 0x0,
-  .sceSblKeymgrCleartKey_addr      = 0x0,
-  .sceSblKeymgrSmCallfunc_addr     = 0x0,
+  .RsaesPkcs1v15Dec2048CRT_addr    = 0x002209B0,
+  .Sha256Hmac_addr                 = 0x00165D80,
+  .AesCbcCfb128Encrypt_addr        = 0x002D40F0,
+  .AesCbcCfb128Decrypt_addr        = 0x002D4320,
+  .sceSblDriverSendMsg_0_addr      = 0x006378E0,
+  .sceSblPfsSetKeys_addr           = 0x00640C90,
+  .sceSblKeymgrSetKeyStorage_addr  = 0x00646050,
+  .sceSblKeymgrSetKeyForPfs_addr   = 0x00648EF0,
+  .sceSblKeymgrCleartKey_addr      = 0x00649280,
+  .sceSblKeymgrSmCallfunc_addr     = 0x00648AC0,
 
   // Patch
-  .vmspace_acquire_ref_addr        = 0x0,
-  .vmspace_free_addr               = 0x0,
-  .vm_map_lock_read_addr           = 0x0,
-  .vm_map_unlock_read_addr         = 0x0,
-  .vm_map_lookup_entry_addr        = 0x0,
-  .proc_rwmem_addr                 = 0x0,
+  .vmspace_acquire_ref_addr        = 0x0034D0B0,
+  .vmspace_free_addr               = 0x0034CEE0,
+  .vm_map_lock_read_addr           = 0x0034D260,
+  .vm_map_unlock_read_addr         = 0x0034D2B0,
+  .vm_map_lookup_entry_addr        = 0x0034D860,
+  .proc_rwmem_addr                 = 0x0013E7A0,
 
   // Fself hooks
-  .sceSblAuthMgrIsLoadable__sceSblACMgrGetPathId_hook        = 0x0,
-  .sceSblAuthMgrIsLoadable2_hook                             = 0x0,
-  .sceSblAuthMgrVerifyHeader_hook1                           = 0x0,
-  .sceSblAuthMgrVerifyHeader_hook2                           = 0x0,
-  .sceSblAuthMgrSmLoadSelfSegment__sceSblServiceMailbox_hook = 0x0,
-  .sceSblAuthMgrSmLoadSelfBlock__sceSblServiceMailbox_hook   = 0x0,
+  .sceSblAuthMgrIsLoadable__sceSblACMgrGetPathId_hook        = 0x00658D2C,
+  .sceSblAuthMgrIsLoadable2_hook                             = 0x00658E7F,
+  .sceSblAuthMgrVerifyHeader_hook1                           = 0x00659636,
+  .sceSblAuthMgrVerifyHeader_hook2                           = 0x0065A2D8,
+  .sceSblAuthMgrSmLoadSelfSegment__sceSblServiceMailbox_hook = 0x0065D29A,
+  .sceSblAuthMgrSmLoadSelfBlock__sceSblServiceMailbox_hook   = 0x0065DEE1,
 
   // Fpkg hooks
-  .sceSblKeymgrSetKeyStorage__sceSblDriverSendMsg_hook       = 0x0,
-  .sceSblKeymgrInvalidateKey__sx_xlock_hook                  = 0x0,
-  .sceSblKeymgrSmCallfunc_npdrm_decrypt_isolated_rif_hook    = 0x0,
-  .sceSblKeymgrSmCallfunc_npdrm_decrypt_rif_new_hook         = 0x0,
-  .mountpfs__sceSblPfsSetKeys_hook1                          = 0x0,
-  .mountpfs__sceSblPfsSetKeys_hook2                          = 0x0,
+  .sceSblKeymgrSetKeyStorage__sceSblDriverSendMsg_hook       = 0x006460F5,
+  .sceSblKeymgrInvalidateKey__sx_xlock_hook                  = 0x0064A11D,
+  .sceSblKeymgrSmCallfunc_npdrm_decrypt_isolated_rif_hook    = 0x006685C0,
+  .sceSblKeymgrSmCallfunc_npdrm_decrypt_rif_new_hook         = 0x006693D3,
+  .mountpfs__sceSblPfsSetKeys_hook1                          = 0x0069FABA,
+  .mountpfs__sceSblPfsSetKeys_hook2                          = 0x0069FCE6,
 
   // SceShellUI patches - debug patches - libkernel_sys.sprx
-  .sceSblRcMgrIsAllowDebugMenuForSettings_patch              = 0x0,
-  .sceSblRcMgrIsStoreMode_patch                              = 0x0,
+  .sceSblRcMgrIsAllowDebugMenuForSettings_patch              = 0x0001D6D0,
+  .sceSblRcMgrIsStoreMode_patch                              = 0x0001DA30,
 
   // SceShellUI patches - remote play patches
-  .CreateUserForIDU_patch                                    = 0x0, // system_ex\app\NPXS20001\eboot.bin
-  .remote_play_menu_patch                                    = 0x0, // system_ex\app\NPXS20001\psm\Application\app.exe.sprx
+  .CreateUserForIDU_patch                                    = 0x001A0510, // system_ex\app\NPXS20001\eboot.bin
+  .remote_play_menu_patch                                    = 0x00E9F7B1, // system_ex\app\NPXS20001\psm\Application\app.exe.sprx
 
   // SceRemotePlay patches - remote play patches - system\vsh\app\NPXS21006
-  .SceRemotePlay_patch1                                      = 0x0,
-  .SceRemotePlay_patch2                                      = 0x0,
+  .SceRemotePlay_patch1                                      = 0x0003CED6,
+  .SceRemotePlay_patch2                                      = 0x0003CEF1,
 
   // SceShellCore patches - call sceKernelIsGenuineCEX
-  .sceKernelIsGenuineCEX_patch1    = 0x0,
-  .sceKernelIsGenuineCEX_patch2    = 0x0,
-  .sceKernelIsGenuineCEX_patch3    = 0x0,
-  .sceKernelIsGenuineCEX_patch4    = 0x0,
+  .sceKernelIsGenuineCEX_patch1    = 0x00186170,
+  .sceKernelIsGenuineCEX_patch2    = 0x0081ED20,
+  .sceKernelIsGenuineCEX_patch3    = 0x00869BA3,
+  .sceKernelIsGenuineCEX_patch4    = 0x009F7550,
 
   // SceShellCore patches - call nidf_libSceDipsw
-  .nidf_libSceDipsw_patch1         = 0x0,
-  .nidf_libSceDipsw_patch2         = 0x0,
-  .nidf_libSceDipsw_patch3         = 0x0,
-  .nidf_libSceDipsw_patch4         = 0x0,
+  .nidf_libSceDipsw_patch1         = 0x0018619A,
+  .nidf_libSceDipsw_patch2         = 0x0025C923,
+  .nidf_libSceDipsw_patch3         = 0x0081ED4A,
+  .nidf_libSceDipsw_patch4         = 0x009F757A,
 
   // SceShellCore patches - bypass firmware checks
-  .check_disc_root_param_patch     = 0x0,
-  .app_installer_patch             = 0x0,
-  .check_system_version            = 0x0,
-  .check_title_system_update_patch = 0x0,
+  .check_disc_root_param_patch     = 0x00146642,
+  .app_installer_patch             = 0x00146731,
+  .check_system_version            = 0x003E3029,
+  .check_title_system_update_patch = 0x003E65D0,
 
   // SceShellCore patches - enable remote pkg installer
-  .enable_data_mount_patch         = 0x0,
+  .enable_data_mount_patch         = 0x0033FF4C,
 
   // SceShellCore patches - enable VR without spoof
-  .enable_psvr_patch               = 0x0,
+  .enable_psvr_patch               = 0x00DBABB0,
 
   // SceShellCore patches - enable fpkg
-  .enable_fpkg_patch               = 0x0,
+  .enable_fpkg_patch               = 0x003F7222,
 
   // SceShellCore patches - use `free` prefix instead `fake`
-  .fake_free_patch                 = 0x0,
+  .fake_free_patch                 = 0x00F9FB11,
 
   // SceShellCore patches - enable official external HDD support
-  .pkg_installer_patch             = 0x0,
-  .ext_hdd_patch                   = 0x0,
+  .pkg_installer_patch             = 0x009E0031,
+  .ext_hdd_patch                   = 0x0060081D,
 
   // SceShellCore patches - enable debug trophies
-  .debug_trophies_patch            = 0x0,
+  .debug_trophies_patch            = 0x0071CDD9,
 
   // SceShellCore patches - disable screenshot block
-  .disable_screenshot_patch        = 0x0,
+  .disable_screenshot_patch        = 0x000DACD6,
 
   // Process structure offsets
-  .proc_p_comm_offset = 0x44C,
-  .proc_path_offset   = 0x46C,
+  .proc_p_comm_offset = 0x450,
+  .proc_path_offset   = 0x470,
 };
 
 // clang-format on

--- a/kpayload/source/offsets/650.c
+++ b/kpayload/source/offsets/650.c
@@ -6,135 +6,135 @@
 
 const struct kpayload_offsets offsets_650 PAYLOAD_RDATA = {
   // data
-  .XFAST_SYSCALL_addr              = 0x0,
-  .PRISON0_addr                    = 0x0,
-  .ROOTVNODE_addr                  = 0x0,
-  .M_TEMP_addr                     = 0x0,
-  .MINI_SYSCORE_SELF_BINARY_addr   = 0x0,
-  .ALLPROC_addr                    = 0x0,
-  .SBL_DRIVER_MAPPED_PAGES_addr    = 0x0,
-  .SBL_PFS_SX_addr                 = 0x0,
-  .SBL_KEYMGR_KEY_SLOTS_addr       = 0x0,
-  .SBL_KEYMGR_KEY_RBTREE_addr      = 0x0,
-  .SBL_KEYMGR_BUF_VA_addr          = 0x0,
-  .SBL_KEYMGR_BUF_GVA_addr         = 0x0,
-  .FPU_CTX_addr                    = 0x0,
-  .SYSENT_addr                     = 0x0,
+  .XFAST_SYSCALL_addr              = 0x000001C0,
+  .PRISON0_addr                    = 0x0113D4F8,
+  .ROOTVNODE_addr                  = 0x02300320,
+  .M_TEMP_addr                     = 0x01540EB0,
+  .MINI_SYSCORE_SELF_BINARY_addr   = 0x0156A588,
+  .ALLPROC_addr                    = 0x022BBE80,
+  .SBL_DRIVER_MAPPED_PAGES_addr    = 0x0266AC68,
+  .SBL_PFS_SX_addr                 = 0x02679040,
+  .SBL_KEYMGR_KEY_SLOTS_addr       = 0x02694570,
+  .SBL_KEYMGR_KEY_RBTREE_addr      = 0x02694580,
+  .SBL_KEYMGR_BUF_VA_addr          = 0x02698000,
+  .SBL_KEYMGR_BUF_GVA_addr         = 0x02698808,
+  .FPU_CTX_addr                    = 0x02694080,
+  .SYSENT_addr                     = 0x0111D000,
 
   // common
-  .memcmp_addr                     = 0x0,
-  ._sx_xlock_addr                  = 0x0,
-  ._sx_xunlock_addr                = 0x0,
-  .malloc_addr                     = 0x0,
-  .free_addr                       = 0x0,
-  .strstr_addr                     = 0x0,
-  .fpu_kern_enter_addr             = 0x0,
-  .fpu_kern_leave_addr             = 0x0,
-  .memcpy_addr                     = 0x0,
-  .memset_addr                     = 0x0,
-  .strlen_addr                     = 0x0,
-  .printf_addr                     = 0x0,
-  .eventhandler_register_addr      = 0x0,
+  .memcmp_addr                     = 0x00207A90,
+  ._sx_xlock_addr                  = 0x000426C0,
+  ._sx_xunlock_addr                = 0x00042880,
+  .malloc_addr                     = 0x0000D7A0,
+  .free_addr                       = 0x0000D9A0,
+  .strstr_addr                     = 0x00481440,
+  .fpu_kern_enter_addr             = 0x0036B330,
+  .fpu_kern_leave_addr             = 0x0036B420,
+  .memcpy_addr                     = 0x003C1200,
+  .memset_addr                     = 0x00168420,
+  .strlen_addr                     = 0x00243030,
+  .printf_addr                     = 0x00122ED0,
+  .eventhandler_register_addr      = 0x00402AD0,
 
   // Fself
-  .sceSblACMgrGetPathId_addr       = 0x0,
-  .sceSblServiceMailbox_addr       = 0x0,
-  .sceSblAuthMgrSmIsLoadable2_addr = 0x0,
-  ._sceSblAuthMgrGetSelfInfo_addr  = 0x0,
-  ._sceSblAuthMgrSmStart_addr      = 0x0,
-  .sceSblAuthMgrVerifyHeader_addr  = 0x0,
+  .sceSblACMgrGetPathId_addr       = 0x002338C0,
+  .sceSblServiceMailbox_addr       = 0x0064C860,
+  .sceSblAuthMgrSmIsLoadable2_addr = 0x0065C400,
+  ._sceSblAuthMgrGetSelfInfo_addr  = 0x0065CC70,
+  ._sceSblAuthMgrSmStart_addr      = 0x0065D0F0,
+  .sceSblAuthMgrVerifyHeader_addr  = 0x0065C460,
 
   // Fpkg
-  .RsaesPkcs1v15Dec2048CRT_addr    = 0x0,
-  .Sha256Hmac_addr                 = 0x0,
-  .AesCbcCfb128Encrypt_addr        = 0x0,
-  .AesCbcCfb128Decrypt_addr        = 0x0,
-  .sceSblDriverSendMsg_0_addr      = 0x0,
-  .sceSblPfsSetKeys_addr           = 0x0,
-  .sceSblKeymgrSetKeyStorage_addr  = 0x0,
-  .sceSblKeymgrSetKeyForPfs_addr   = 0x0,
-  .sceSblKeymgrCleartKey_addr      = 0x0,
-  .sceSblKeymgrSmCallfunc_addr     = 0x0,
+  .RsaesPkcs1v15Dec2048CRT_addr    = 0x001D5CA0,
+  .Sha256Hmac_addr                 = 0x003357C0,
+  .AesCbcCfb128Encrypt_addr        = 0x003BFF70,
+  .AesCbcCfb128Decrypt_addr        = 0x003C01A0,
+  .sceSblDriverSendMsg_0_addr      = 0x00637720,
+  .sceSblPfsSetKeys_addr           = 0x00641160,
+  .sceSblKeymgrSetKeyStorage_addr  = 0x00646A40,
+  .sceSblKeymgrSetKeyForPfs_addr   = 0x00649440,
+  .sceSblKeymgrCleartKey_addr      = 0x006497C0,
+  .sceSblKeymgrSmCallfunc_addr     = 0x00649010,
 
   // Patch
-  .vmspace_acquire_ref_addr        = 0x0,
-  .vmspace_free_addr               = 0x0,
-  .vm_map_lock_read_addr           = 0x0,
-  .vm_map_unlock_read_addr         = 0x0,
-  .vm_map_lookup_entry_addr        = 0x0,
-  .proc_rwmem_addr                 = 0x0,
+  .vmspace_acquire_ref_addr        = 0x0044C7E0,
+  .vmspace_free_addr               = 0x0044C610,
+  .vm_map_lock_read_addr           = 0x0044C990,
+  .vm_map_unlock_read_addr         = 0x0044C9E0,
+  .vm_map_lookup_entry_addr        = 0x0044CF80,
+  .proc_rwmem_addr                 = 0x0010EA60,
 
   // Fself hooks
-  .sceSblAuthMgrIsLoadable__sceSblACMgrGetPathId_hook        = 0x0,
-  .sceSblAuthMgrIsLoadable2_hook                             = 0x0,
-  .sceSblAuthMgrVerifyHeader_hook1                           = 0x0,
-  .sceSblAuthMgrVerifyHeader_hook2                           = 0x0,
-  .sceSblAuthMgrSmLoadSelfSegment__sceSblServiceMailbox_hook = 0x0,
-  .sceSblAuthMgrSmLoadSelfBlock__sceSblServiceMailbox_hook   = 0x0,
+  .sceSblAuthMgrIsLoadable__sceSblACMgrGetPathId_hook        = 0x0065817C,
+  .sceSblAuthMgrIsLoadable2_hook                             = 0x006582CF,
+  .sceSblAuthMgrVerifyHeader_hook1                           = 0x00658A86,
+  .sceSblAuthMgrVerifyHeader_hook2                           = 0x00659718,
+  .sceSblAuthMgrSmLoadSelfSegment__sceSblServiceMailbox_hook = 0x0065F31A,
+  .sceSblAuthMgrSmLoadSelfBlock__sceSblServiceMailbox_hook   = 0x0065FF61,
 
   // Fpkg hooks
-  .sceSblKeymgrSetKeyStorage__sceSblDriverSendMsg_hook       = 0x0,
-  .sceSblKeymgrInvalidateKey__sx_xlock_hook                  = 0x0,
-  .sceSblKeymgrSmCallfunc_npdrm_decrypt_isolated_rif_hook    = 0x0,
-  .sceSblKeymgrSmCallfunc_npdrm_decrypt_rif_new_hook         = 0x0,
-  .mountpfs__sceSblPfsSetKeys_hook1                          = 0x0,
-  .mountpfs__sceSblPfsSetKeys_hook2                          = 0x0,
+  .sceSblKeymgrSetKeyStorage__sceSblDriverSendMsg_hook       = 0x00646AE5,
+  .sceSblKeymgrInvalidateKey__sx_xlock_hook                  = 0x0064A67D,
+  .sceSblKeymgrSmCallfunc_npdrm_decrypt_isolated_rif_hook    = 0x00667F00,
+  .sceSblKeymgrSmCallfunc_npdrm_decrypt_rif_new_hook         = 0x00668D13,
+  .mountpfs__sceSblPfsSetKeys_hook1                          = 0x006CC865,
+  .mountpfs__sceSblPfsSetKeys_hook2                          = 0x006CCA91,
 
   // SceShellUI patches - debug patches - libkernel_sys.sprx
-  .sceSblRcMgrIsAllowDebugMenuForSettings_patch              = 0x0,
-  .sceSblRcMgrIsStoreMode_patch                              = 0x0,
+  .sceSblRcMgrIsAllowDebugMenuForSettings_patch              = 0x0001D670,
+  .sceSblRcMgrIsStoreMode_patch                              = 0x0001D9D0,
 
   // SceShellUI patches - remote play patches
-  .CreateUserForIDU_patch                                    = 0x0, // system_ex\app\NPXS20001\eboot.bin
-  .remote_play_menu_patch                                    = 0x0, // system_ex\app\NPXS20001\psm\Application\app.exe.sprx
+  .CreateUserForIDU_patch                                    = 0x001A08B0, // system_ex\app\NPXS20001\eboot.bin
+  .remote_play_menu_patch                                    = 0x00EC6801, // system_ex\app\NPXS20001\psm\Application\app.exe.sprx
 
   // SceRemotePlay patches - remote play patches - system\vsh\app\NPXS21006
-  .SceRemotePlay_patch1                                      = 0x0,
-  .SceRemotePlay_patch2                                      = 0x0,
+  .SceRemotePlay_patch1                                      = 0x0010C6D4,
+  .SceRemotePlay_patch2                                      = 0x0010C6EF,
 
   // SceShellCore patches - call sceKernelIsGenuineCEX
-  .sceKernelIsGenuineCEX_patch1    = 0x0,
-  .sceKernelIsGenuineCEX_patch2    = 0x0,
-  .sceKernelIsGenuineCEX_patch3    = 0x0,
-  .sceKernelIsGenuineCEX_patch4    = 0x0,
+  .sceKernelIsGenuineCEX_patch1    = 0x001898A2,
+  .sceKernelIsGenuineCEX_patch2    = 0x00829312,
+  .sceKernelIsGenuineCEX_patch3    = 0x00873EC2,
+  .sceKernelIsGenuineCEX_patch4    = 0x00A04A52,
 
   // SceShellCore patches - call nidf_libSceDipsw
-  .nidf_libSceDipsw_patch1         = 0x0,
-  .nidf_libSceDipsw_patch2         = 0x0,
-  .nidf_libSceDipsw_patch3         = 0x0,
-  .nidf_libSceDipsw_patch4         = 0x0,
+  .nidf_libSceDipsw_patch1         = 0x001898D0,
+  .nidf_libSceDipsw_patch2         = 0x002543F7,
+  .nidf_libSceDipsw_patch3         = 0x00829340,
+  .nidf_libSceDipsw_patch4         = 0x00A04A80,
 
   // SceShellCore patches - bypass firmware checks
-  .check_disc_root_param_patch     = 0x0,
-  .app_installer_patch             = 0x0,
-  .check_system_version            = 0x0,
-  .check_title_system_update_patch = 0x0,
+  .check_disc_root_param_patch     = 0x00149D9D,
+  .app_installer_patch             = 0x00149E90,
+  .check_system_version            = 0x003DB768,
+  .check_title_system_update_patch = 0x003DED30,
 
   // SceShellCore patches - enable remote pkg installer
-  .enable_data_mount_patch         = 0x0,
+  .enable_data_mount_patch         = 0x0033904E,
 
   // SceShellCore patches - enable VR without spoof
-  .enable_psvr_patch               = 0x0,
+  .enable_psvr_patch               = 0x00DCF950,
 
   // SceShellCore patches - enable fpkg
-  .enable_fpkg_patch               = 0x0,
+  .enable_fpkg_patch               = 0x003EFB00,
 
   // SceShellCore patches - use `free` prefix instead `fake`
-  .fake_free_patch                 = 0x0,
+  .fake_free_patch                 = 0x00FC3EF1,
 
   // SceShellCore patches - enable official external HDD support
-  .pkg_installer_patch             = 0x0,
-  .ext_hdd_patch                   = 0x0,
+  .pkg_installer_patch             = 0x009ED1D1,
+  .ext_hdd_patch                   = 0x00604DAD,
 
   // SceShellCore patches - enable debug trophies
-  .debug_trophies_patch            = 0x0,
+  .debug_trophies_patch            = 0x0071F0B9,
 
   // SceShellCore patches - disable screenshot block
-  .disable_screenshot_patch        = 0x0,
+  .disable_screenshot_patch        = 0x000DD176,
 
   // Process structure offsets
-  .proc_p_comm_offset = 0x44C,
-  .proc_path_offset   = 0x46C,
+  .proc_p_comm_offset = 0x454,
+  .proc_path_offset   = 0x474,
 };
 
 // clang-format on

--- a/kpayload/source/offsets/651.c
+++ b/kpayload/source/offsets/651.c
@@ -6,135 +6,135 @@
 
 const struct kpayload_offsets offsets_651 PAYLOAD_RDATA = {
   // data
-  .XFAST_SYSCALL_addr              = 0x0,
-  .PRISON0_addr                    = 0x0,
-  .ROOTVNODE_addr                  = 0x0,
-  .M_TEMP_addr                     = 0x0,
-  .MINI_SYSCORE_SELF_BINARY_addr   = 0x0,
-  .ALLPROC_addr                    = 0x0,
-  .SBL_DRIVER_MAPPED_PAGES_addr    = 0x0,
-  .SBL_PFS_SX_addr                 = 0x0,
-  .SBL_KEYMGR_KEY_SLOTS_addr       = 0x0,
-  .SBL_KEYMGR_KEY_RBTREE_addr      = 0x0,
-  .SBL_KEYMGR_BUF_VA_addr          = 0x0,
-  .SBL_KEYMGR_BUF_GVA_addr         = 0x0,
-  .FPU_CTX_addr                    = 0x0,
-  .SYSENT_addr                     = 0x0,
+  .XFAST_SYSCALL_addr              = 0x000001C0,
+  .PRISON0_addr                    = 0x0113D4F8,
+  .ROOTVNODE_addr                  = 0x02300320,
+  .M_TEMP_addr                     = 0x01540EB0,
+  .MINI_SYSCORE_SELF_BINARY_addr   = 0x0156A588,
+  .ALLPROC_addr                    = 0x022BBE80,
+  .SBL_DRIVER_MAPPED_PAGES_addr    = 0x0266AC68,
+  .SBL_PFS_SX_addr                 = 0x02679040,
+  .SBL_KEYMGR_KEY_SLOTS_addr       = 0x02694570,
+  .SBL_KEYMGR_KEY_RBTREE_addr      = 0x02694580,
+  .SBL_KEYMGR_BUF_VA_addr          = 0x02698000,
+  .SBL_KEYMGR_BUF_GVA_addr         = 0x02698808,
+  .FPU_CTX_addr                    = 0x02694080,
+  .SYSENT_addr                     = 0x0111D000,
 
   // common
-  .memcmp_addr                     = 0x0,
-  ._sx_xlock_addr                  = 0x0,
-  ._sx_xunlock_addr                = 0x0,
-  .malloc_addr                     = 0x0,
-  .free_addr                       = 0x0,
-  .strstr_addr                     = 0x0,
-  .fpu_kern_enter_addr             = 0x0,
-  .fpu_kern_leave_addr             = 0x0,
-  .memcpy_addr                     = 0x0,
-  .memset_addr                     = 0x0,
-  .strlen_addr                     = 0x0,
-  .printf_addr                     = 0x0,
-  .eventhandler_register_addr      = 0x0,
+  .memcmp_addr                     = 0x00207A90,
+  ._sx_xlock_addr                  = 0x000426C0,
+  ._sx_xunlock_addr                = 0x00042880,
+  .malloc_addr                     = 0x0000D7A0,
+  .free_addr                       = 0x0000D9A0,
+  .strstr_addr                     = 0x00481440,
+  .fpu_kern_enter_addr             = 0x0036B330,
+  .fpu_kern_leave_addr             = 0x0036B420,
+  .memcpy_addr                     = 0x003C1200,
+  .memset_addr                     = 0x00168420,
+  .strlen_addr                     = 0x00243030,
+  .printf_addr                     = 0x00122ED0,
+  .eventhandler_register_addr      = 0x00402AD0,
 
   // Fself
-  .sceSblACMgrGetPathId_addr       = 0x0,
-  .sceSblServiceMailbox_addr       = 0x0,
-  .sceSblAuthMgrSmIsLoadable2_addr = 0x0,
-  ._sceSblAuthMgrGetSelfInfo_addr  = 0x0,
-  ._sceSblAuthMgrSmStart_addr      = 0x0,
-  .sceSblAuthMgrVerifyHeader_addr  = 0x0,
+  .sceSblACMgrGetPathId_addr       = 0x002338C0,
+  .sceSblServiceMailbox_addr       = 0x0064C860,
+  .sceSblAuthMgrSmIsLoadable2_addr = 0x0065C400,
+  ._sceSblAuthMgrGetSelfInfo_addr  = 0x0065CC70,
+  ._sceSblAuthMgrSmStart_addr      = 0x0065D0F0,
+  .sceSblAuthMgrVerifyHeader_addr  = 0x0065C460,
 
   // Fpkg
-  .RsaesPkcs1v15Dec2048CRT_addr    = 0x0,
-  .Sha256Hmac_addr                 = 0x0,
-  .AesCbcCfb128Encrypt_addr        = 0x0,
-  .AesCbcCfb128Decrypt_addr        = 0x0,
-  .sceSblDriverSendMsg_0_addr      = 0x0,
-  .sceSblPfsSetKeys_addr           = 0x0,
-  .sceSblKeymgrSetKeyStorage_addr  = 0x0,
-  .sceSblKeymgrSetKeyForPfs_addr   = 0x0,
-  .sceSblKeymgrCleartKey_addr      = 0x0,
-  .sceSblKeymgrSmCallfunc_addr     = 0x0,
+  .RsaesPkcs1v15Dec2048CRT_addr    = 0x001D5CA0,
+  .Sha256Hmac_addr                 = 0x003357C0,
+  .AesCbcCfb128Encrypt_addr        = 0x003BFF70,
+  .AesCbcCfb128Decrypt_addr        = 0x003C01A0,
+  .sceSblDriverSendMsg_0_addr      = 0x00637720,
+  .sceSblPfsSetKeys_addr           = 0x00641160,
+  .sceSblKeymgrSetKeyStorage_addr  = 0x00646A40,
+  .sceSblKeymgrSetKeyForPfs_addr   = 0x00649440,
+  .sceSblKeymgrCleartKey_addr      = 0x006497C0,
+  .sceSblKeymgrSmCallfunc_addr     = 0x00649010,
 
   // Patch
-  .vmspace_acquire_ref_addr        = 0x0,
-  .vmspace_free_addr               = 0x0,
-  .vm_map_lock_read_addr           = 0x0,
-  .vm_map_unlock_read_addr         = 0x0,
-  .vm_map_lookup_entry_addr        = 0x0,
-  .proc_rwmem_addr                 = 0x0,
+  .vmspace_acquire_ref_addr        = 0x0044C7E0,
+  .vmspace_free_addr               = 0x0044C610,
+  .vm_map_lock_read_addr           = 0x0044C990,
+  .vm_map_unlock_read_addr         = 0x0044C9E0,
+  .vm_map_lookup_entry_addr        = 0x0044CF80,
+  .proc_rwmem_addr                 = 0x0010EA60,
 
   // Fself hooks
-  .sceSblAuthMgrIsLoadable__sceSblACMgrGetPathId_hook        = 0x0,
-  .sceSblAuthMgrIsLoadable2_hook                             = 0x0,
-  .sceSblAuthMgrVerifyHeader_hook1                           = 0x0,
-  .sceSblAuthMgrVerifyHeader_hook2                           = 0x0,
-  .sceSblAuthMgrSmLoadSelfSegment__sceSblServiceMailbox_hook = 0x0,
-  .sceSblAuthMgrSmLoadSelfBlock__sceSblServiceMailbox_hook   = 0x0,
+  .sceSblAuthMgrIsLoadable__sceSblACMgrGetPathId_hook        = 0x002338C0,
+  .sceSblAuthMgrIsLoadable2_hook                             = 0x006582CF,
+  .sceSblAuthMgrVerifyHeader_hook1                           = 0x00658A86,
+  .sceSblAuthMgrVerifyHeader_hook2                           = 0x00659718,
+  .sceSblAuthMgrSmLoadSelfSegment__sceSblServiceMailbox_hook = 0x0065F31A,
+  .sceSblAuthMgrSmLoadSelfBlock__sceSblServiceMailbox_hook   = 0x0065FF61,
 
   // Fpkg hooks
-  .sceSblKeymgrSetKeyStorage__sceSblDriverSendMsg_hook       = 0x0,
-  .sceSblKeymgrInvalidateKey__sx_xlock_hook                  = 0x0,
-  .sceSblKeymgrSmCallfunc_npdrm_decrypt_isolated_rif_hook    = 0x0,
-  .sceSblKeymgrSmCallfunc_npdrm_decrypt_rif_new_hook         = 0x0,
-  .mountpfs__sceSblPfsSetKeys_hook1                          = 0x0,
-  .mountpfs__sceSblPfsSetKeys_hook2                          = 0x0,
+  .sceSblKeymgrSetKeyStorage__sceSblDriverSendMsg_hook       = 0x00646AE5,
+  .sceSblKeymgrInvalidateKey__sx_xlock_hook                  = 0x0064A67D,
+  .sceSblKeymgrSmCallfunc_npdrm_decrypt_isolated_rif_hook    = 0x00667F00,
+  .sceSblKeymgrSmCallfunc_npdrm_decrypt_rif_new_hook         = 0x00668D13,
+  .mountpfs__sceSblPfsSetKeys_hook1                          = 0x006CC865,
+  .mountpfs__sceSblPfsSetKeys_hook2                          = 0x006CCA91,
 
   // SceShellUI patches - debug patches - libkernel_sys.sprx
-  .sceSblRcMgrIsAllowDebugMenuForSettings_patch              = 0x0,
-  .sceSblRcMgrIsStoreMode_patch                              = 0x0,
+  .sceSblRcMgrIsAllowDebugMenuForSettings_patch              = 0x0001D670,
+  .sceSblRcMgrIsStoreMode_patch                              = 0x0001D9D0,
 
   // SceShellUI patches - remote play patches
-  .CreateUserForIDU_patch                                    = 0x0, // system_ex\app\NPXS20001\eboot.bin
-  .remote_play_menu_patch                                    = 0x0, // system_ex\app\NPXS20001\psm\Application\app.exe.sprx
+  .CreateUserForIDU_patch                                    = 0x001A08B0, // system_ex\app\NPXS20001\eboot.bin
+  .remote_play_menu_patch                                    = 0x00EC6801, // system_ex\app\NPXS20001\psm\Application\app.exe.sprx
 
   // SceRemotePlay patches - remote play patches - system\vsh\app\NPXS21006
-  .SceRemotePlay_patch1                                      = 0x0,
-  .SceRemotePlay_patch2                                      = 0x0,
+  .SceRemotePlay_patch1                                      = 0x0010C6D4,
+  .SceRemotePlay_patch2                                      = 0x0010C6EF,
 
   // SceShellCore patches - call sceKernelIsGenuineCEX
-  .sceKernelIsGenuineCEX_patch1    = 0x0,
-  .sceKernelIsGenuineCEX_patch2    = 0x0,
-  .sceKernelIsGenuineCEX_patch3    = 0x0,
-  .sceKernelIsGenuineCEX_patch4    = 0x0,
+  .sceKernelIsGenuineCEX_patch1    = 0x001898A2,
+  .sceKernelIsGenuineCEX_patch2    = 0x008294A2,
+  .sceKernelIsGenuineCEX_patch3    = 0x00874052,
+  .sceKernelIsGenuineCEX_patch4    = 0x00A04BD2,
 
   // SceShellCore patches - call nidf_libSceDipsw
-  .nidf_libSceDipsw_patch1         = 0x0,
-  .nidf_libSceDipsw_patch2         = 0x0,
-  .nidf_libSceDipsw_patch3         = 0x0,
-  .nidf_libSceDipsw_patch4         = 0x0,
+  .nidf_libSceDipsw_patch1         = 0x001898D0,
+  .nidf_libSceDipsw_patch2         = 0x002543F7,
+  .nidf_libSceDipsw_patch3         = 0x008294D0,
+  .nidf_libSceDipsw_patch4         = 0x00A04C00,
 
   // SceShellCore patches - bypass firmware checks
-  .check_disc_root_param_patch     = 0x0,
-  .app_installer_patch             = 0x0,
-  .check_system_version            = 0x0,
-  .check_title_system_update_patch = 0x0,
+  .check_disc_root_param_patch     = 0x00149D9D,
+  .app_installer_patch             = 0x00149E90,
+  .check_system_version            = 0x003DB768,
+  .check_title_system_update_patch = 0x003DED30,
 
   // SceShellCore patches - enable remote pkg installer
-  .enable_data_mount_patch         = 0x0,
+  .enable_data_mount_patch         = 0x0033904E,
 
   // SceShellCore patches - enable VR without spoof
-  .enable_psvr_patch               = 0x0,
+  .enable_psvr_patch               = 0x00DCFAD0,
 
   // SceShellCore patches - enable fpkg
-  .enable_fpkg_patch               = 0x0,
+  .enable_fpkg_patch               = 0x003EFB00,
 
   // SceShellCore patches - use `free` prefix instead `fake`
-  .fake_free_patch                 = 0x0,
+  .fake_free_patch                 = 0x00FC40D1,
 
   // SceShellCore patches - enable official external HDD support
-  .pkg_installer_patch             = 0x0,
-  .ext_hdd_patch                   = 0x0,
+  .pkg_installer_patch             = 0x009ED351,
+  .ext_hdd_patch                   = 0x00604F3D,
 
   // SceShellCore patches - enable debug trophies
-  .debug_trophies_patch            = 0x0,
+  .debug_trophies_patch            = 0x0071F249,
 
   // SceShellCore patches - disable screenshot block
-  .disable_screenshot_patch        = 0x0,
+  .disable_screenshot_patch        = 0x000DD176,
 
   // Process structure offsets
-  .proc_p_comm_offset = 0x44C,
-  .proc_path_offset   = 0x46C,
+  .proc_p_comm_offset = 0x454,
+  .proc_path_offset   = 0x474,
 };
 
 // clang-format on

--- a/kpayload/source/offsets/670.c
+++ b/kpayload/source/offsets/670.c
@@ -6,135 +6,135 @@
 
 const struct kpayload_offsets offsets_670 PAYLOAD_RDATA = {
   // data
-  .XFAST_SYSCALL_addr              = 0x0,
-  .PRISON0_addr                    = 0x0,
-  .ROOTVNODE_addr                  = 0x0,
-  .M_TEMP_addr                     = 0x0,
-  .MINI_SYSCORE_SELF_BINARY_addr   = 0x0,
-  .ALLPROC_addr                    = 0x0,
-  .SBL_DRIVER_MAPPED_PAGES_addr    = 0x0,
-  .SBL_PFS_SX_addr                 = 0x0,
-  .SBL_KEYMGR_KEY_SLOTS_addr       = 0x0,
-  .SBL_KEYMGR_KEY_RBTREE_addr      = 0x0,
-  .SBL_KEYMGR_BUF_VA_addr          = 0x0,
-  .SBL_KEYMGR_BUF_GVA_addr         = 0x0,
-  .FPU_CTX_addr                    = 0x0,
-  .SYSENT_addr                     = 0x0,
+  .XFAST_SYSCALL_addr              = 0x000001C0,
+  .PRISON0_addr                    = 0x0113E518,
+  .ROOTVNODE_addr                  = 0x02300320,
+  .M_TEMP_addr                     = 0x01540EB0,
+  .MINI_SYSCORE_SELF_BINARY_addr   = 0x0156A588,
+  .ALLPROC_addr                    = 0x022BBE80,
+  .SBL_DRIVER_MAPPED_PAGES_addr    = 0x0266AC68,
+  .SBL_PFS_SX_addr                 = 0x02679040,
+  .SBL_KEYMGR_KEY_SLOTS_addr       = 0x02694570,
+  .SBL_KEYMGR_KEY_RBTREE_addr      = 0x02694580,
+  .SBL_KEYMGR_BUF_VA_addr          = 0x02698000,
+  .SBL_KEYMGR_BUF_GVA_addr         = 0x02698808,
+  .FPU_CTX_addr                    = 0x02694080,
+  .SYSENT_addr                     = 0x0111E000,
 
   // common
-  .memcmp_addr                     = 0x0,
-  ._sx_xlock_addr                  = 0x0,
-  ._sx_xunlock_addr                = 0x0,
-  .malloc_addr                     = 0x0,
-  .free_addr                       = 0x0,
-  .strstr_addr                     = 0x0,
-  .fpu_kern_enter_addr             = 0x0,
-  .fpu_kern_leave_addr             = 0x0,
-  .memcpy_addr                     = 0x0,
-  .memset_addr                     = 0x0,
-  .strlen_addr                     = 0x0,
-  .printf_addr                     = 0x0,
-  .eventhandler_register_addr      = 0x0,
+  .memcmp_addr                     = 0x00207E40,
+  ._sx_xlock_addr                  = 0x000426C0,
+  ._sx_xunlock_addr                = 0x00042880,
+  .malloc_addr                     = 0x0000D7A0,
+  .free_addr                       = 0x0000D9A0,
+  .strstr_addr                     = 0x004817F0,
+  .fpu_kern_enter_addr             = 0x0036B6E0,
+  .fpu_kern_leave_addr             = 0x0036B7D0,
+  .memcpy_addr                     = 0x003C15B0,
+  .memset_addr                     = 0x001687D0,
+  .strlen_addr                     = 0x002433E0,
+  .printf_addr                     = 0x00123280,
+  .eventhandler_register_addr      = 0x00402E80,
 
   // Fself
-  .sceSblACMgrGetPathId_addr       = 0x0,
-  .sceSblServiceMailbox_addr       = 0x0,
-  .sceSblAuthMgrSmIsLoadable2_addr = 0x0,
-  ._sceSblAuthMgrGetSelfInfo_addr  = 0x0,
-  ._sceSblAuthMgrSmStart_addr      = 0x0,
-  .sceSblAuthMgrVerifyHeader_addr  = 0x0,
+  .sceSblACMgrGetPathId_addr       = 0x00233C70,
+  .sceSblServiceMailbox_addr       = 0x0064CC20,
+  .sceSblAuthMgrSmIsLoadable2_addr = 0x0065D7A0,
+  ._sceSblAuthMgrGetSelfInfo_addr  = 0x0065E010,
+  ._sceSblAuthMgrSmStart_addr      = 0x0065E490,
+  .sceSblAuthMgrVerifyHeader_addr  = 0x0065D800,
 
   // Fpkg
-  .RsaesPkcs1v15Dec2048CRT_addr    = 0x0,
-  .Sha256Hmac_addr                 = 0x0,
-  .AesCbcCfb128Encrypt_addr        = 0x0,
-  .AesCbcCfb128Decrypt_addr        = 0x0,
-  .sceSblDriverSendMsg_0_addr      = 0x0,
-  .sceSblPfsSetKeys_addr           = 0x0,
-  .sceSblKeymgrSetKeyStorage_addr  = 0x0,
-  .sceSblKeymgrSetKeyForPfs_addr   = 0x0,
-  .sceSblKeymgrCleartKey_addr      = 0x0,
-  .sceSblKeymgrSmCallfunc_addr     = 0x0,
+  .RsaesPkcs1v15Dec2048CRT_addr    = 0x001D6050,
+  .Sha256Hmac_addr                 = 0x00335B70,
+  .AesCbcCfb128Encrypt_addr        = 0x003C0320,
+  .AesCbcCfb128Decrypt_addr        = 0x003C0550,
+  .sceSblDriverSendMsg_0_addr      = 0x00637AE0,
+  .sceSblPfsSetKeys_addr           = 0x00641520,
+  .sceSblKeymgrSetKeyStorage_addr  = 0x00646E00,
+  .sceSblKeymgrSetKeyForPfs_addr   = 0x00649800,
+  .sceSblKeymgrCleartKey_addr      = 0x00649B80,
+  .sceSblKeymgrSmCallfunc_addr     = 0x006493D0,
 
   // Patch
-  .vmspace_acquire_ref_addr        = 0x0,
-  .vmspace_free_addr               = 0x0,
-  .vm_map_lock_read_addr           = 0x0,
-  .vm_map_unlock_read_addr         = 0x0,
-  .vm_map_lookup_entry_addr        = 0x0,
-  .proc_rwmem_addr                 = 0x0,
+  .vmspace_acquire_ref_addr        = 0x0044CB90,
+  .vmspace_free_addr               = 0x0044C9C0,
+  .vm_map_lock_read_addr           = 0x0044CD40,
+  .vm_map_unlock_read_addr         = 0x0044CD90,
+  .vm_map_lookup_entry_addr        = 0x0044D330,
+  .proc_rwmem_addr                 = 0x0010EE10,
 
   // Fself hooks
-  .sceSblAuthMgrIsLoadable__sceSblACMgrGetPathId_hook        = 0x0,
-  .sceSblAuthMgrIsLoadable2_hook                             = 0x0,
-  .sceSblAuthMgrVerifyHeader_hook1                           = 0x0,
-  .sceSblAuthMgrVerifyHeader_hook2                           = 0x0,
-  .sceSblAuthMgrSmLoadSelfSegment__sceSblServiceMailbox_hook = 0x0,
-  .sceSblAuthMgrSmLoadSelfBlock__sceSblServiceMailbox_hook   = 0x0,
+  .sceSblAuthMgrIsLoadable__sceSblACMgrGetPathId_hook        = 0x006591BC,
+  .sceSblAuthMgrIsLoadable2_hook                             = 0x0065930F,
+  .sceSblAuthMgrVerifyHeader_hook1                           = 0x00659AC6,
+  .sceSblAuthMgrVerifyHeader_hook2                           = 0x0065A758,
+  .sceSblAuthMgrSmLoadSelfSegment__sceSblServiceMailbox_hook = 0x0066092A,
+  .sceSblAuthMgrSmLoadSelfBlock__sceSblServiceMailbox_hook   = 0x00661571,
 
   // Fpkg hooks
-  .sceSblKeymgrSetKeyStorage__sceSblDriverSendMsg_hook       = 0x0,
-  .sceSblKeymgrInvalidateKey__sx_xlock_hook                  = 0x0,
-  .sceSblKeymgrSmCallfunc_npdrm_decrypt_isolated_rif_hook    = 0x0,
-  .sceSblKeymgrSmCallfunc_npdrm_decrypt_rif_new_hook         = 0x0,
-  .mountpfs__sceSblPfsSetKeys_hook1                          = 0x0,
-  .mountpfs__sceSblPfsSetKeys_hook2                          = 0x0,
+  .sceSblKeymgrSetKeyStorage__sceSblDriverSendMsg_hook       = 0x00646EA5,
+  .sceSblKeymgrInvalidateKey__sx_xlock_hook                  = 0x0064AA3D,
+  .sceSblKeymgrSmCallfunc_npdrm_decrypt_isolated_rif_hook    = 0x00669500,
+  .sceSblKeymgrSmCallfunc_npdrm_decrypt_rif_new_hook         = 0x0066A313,
+  .mountpfs__sceSblPfsSetKeys_hook1                          = 0x006CDF15,
+  .mountpfs__sceSblPfsSetKeys_hook2                          = 0x006CE141,
 
   // SceShellUI patches - debug patches - libkernel_sys.sprx
-  .sceSblRcMgrIsAllowDebugMenuForSettings_patch              = 0x0,
-  .sceSblRcMgrIsStoreMode_patch                              = 0x0,
+  .sceSblRcMgrIsAllowDebugMenuForSettings_patch              = 0x0001D670,
+  .sceSblRcMgrIsStoreMode_patch                              = 0x0001D9D0,
 
   // SceShellUI patches - remote play patches
-  .CreateUserForIDU_patch                                    = 0x0, // system_ex\app\NPXS20001\eboot.bin
-  .remote_play_menu_patch                                    = 0x0, // system_ex\app\NPXS20001\psm\Application\app.exe.sprx
+  .CreateUserForIDU_patch                                    = 0x001A0900, // system_ex\app\NPXS20001\eboot.bin
+  .remote_play_menu_patch                                    = 0x00EC8291, // system_ex\app\NPXS20001\psm\Application\app.exe.sprx
 
   // SceRemotePlay patches - remote play patches - system\vsh\app\NPXS21006
-  .SceRemotePlay_patch1                                      = 0x0,
-  .SceRemotePlay_patch2                                      = 0x0,
+  .SceRemotePlay_patch1                                      = 0x0010C6D4,
+  .SceRemotePlay_patch2                                      = 0x0010C6EF,
 
   // SceShellCore patches - call sceKernelIsGenuineCEX
-  .sceKernelIsGenuineCEX_patch1    = 0x0,
-  .sceKernelIsGenuineCEX_patch2    = 0x0,
-  .sceKernelIsGenuineCEX_patch3    = 0x0,
-  .sceKernelIsGenuineCEX_patch4    = 0x0,
+  .sceKernelIsGenuineCEX_patch1    = 0x00189602,
+  .sceKernelIsGenuineCEX_patch2    = 0x008355A2,
+  .sceKernelIsGenuineCEX_patch3    = 0x008803F2,
+  .sceKernelIsGenuineCEX_patch4    = 0x00A12AF2,
 
   // SceShellCore patches - call nidf_libSceDipsw
-  .nidf_libSceDipsw_patch1         = 0x0,
-  .nidf_libSceDipsw_patch2         = 0x0,
-  .nidf_libSceDipsw_patch3         = 0x0,
-  .nidf_libSceDipsw_patch4         = 0x0,
+  .nidf_libSceDipsw_patch1         = 0x00189630,
+  .nidf_libSceDipsw_patch2         = 0x00254107,
+  .nidf_libSceDipsw_patch3         = 0x008355D0,
+  .nidf_libSceDipsw_patch4         = 0x00A12B20,
 
   // SceShellCore patches - bypass firmware checks
-  .check_disc_root_param_patch     = 0x0,
-  .app_installer_patch             = 0x0,
-  .check_system_version            = 0x0,
-  .check_title_system_update_patch = 0x0,
+  .check_disc_root_param_patch     = 0x00149AFD,
+  .app_installer_patch             = 0x00149BF0,
+  .check_system_version            = 0x003DB6F8,
+  .check_title_system_update_patch = 0x003DECC0,
 
   // SceShellCore patches - enable remote pkg installer
-  .enable_data_mount_patch         = 0x0,
+  .enable_data_mount_patch         = 0x0033943E,
 
   // SceShellCore patches - enable VR without spoof
-  .enable_psvr_patch               = 0x0,
+  .enable_psvr_patch               = 0x00DDDCB0,
 
   // SceShellCore patches - enable fpkg
-  .enable_fpkg_patch               = 0x0,
+  .enable_fpkg_patch               = 0x003EFCF0,
 
   // SceShellCore patches - use `free` prefix instead `fake`
-  .fake_free_patch                 = 0x0,
+  .fake_free_patch                 = 0x00FD2B51,
 
   // SceShellCore patches - enable official external HDD support
-  .pkg_installer_patch             = 0x0,
-  .ext_hdd_patch                   = 0x0,
+  .pkg_installer_patch             = 0x009FB271,
+  .ext_hdd_patch                   = 0x00606A0D,
 
   // SceShellCore patches - enable debug trophies
-  .debug_trophies_patch            = 0x0,
+  .debug_trophies_patch            = 0x00726829,
 
   // SceShellCore patches - disable screenshot block
-  .disable_screenshot_patch        = 0x0,
+  .disable_screenshot_patch        = 0x000DD2A6,
 
   // Process structure offsets
-  .proc_p_comm_offset = 0x44C,
-  .proc_path_offset   = 0x46C,
+  .proc_p_comm_offset = 0x454,
+  .proc_path_offset   = 0x474,
 };
 
 // clang-format on

--- a/kpayload/source/offsets/671.c
+++ b/kpayload/source/offsets/671.c
@@ -6,135 +6,135 @@
 
 const struct kpayload_offsets offsets_671 PAYLOAD_RDATA = {
   // data
-  .XFAST_SYSCALL_addr              = 0x0,
-  .PRISON0_addr                    = 0x0,
-  .ROOTVNODE_addr                  = 0x0,
-  .M_TEMP_addr                     = 0x0,
-  .MINI_SYSCORE_SELF_BINARY_addr   = 0x0,
-  .ALLPROC_addr                    = 0x0,
-  .SBL_DRIVER_MAPPED_PAGES_addr    = 0x0,
-  .SBL_PFS_SX_addr                 = 0x0,
-  .SBL_KEYMGR_KEY_SLOTS_addr       = 0x0,
-  .SBL_KEYMGR_KEY_RBTREE_addr      = 0x0,
-  .SBL_KEYMGR_BUF_VA_addr          = 0x0,
-  .SBL_KEYMGR_BUF_GVA_addr         = 0x0,
-  .FPU_CTX_addr                    = 0x0,
-  .SYSENT_addr                     = 0x0,
+  .XFAST_SYSCALL_addr              = 0x000001C0,
+  .PRISON0_addr                    = 0x0113E518,
+  .ROOTVNODE_addr                  = 0x02300320,
+  .M_TEMP_addr                     = 0x01540EB0,
+  .MINI_SYSCORE_SELF_BINARY_addr   = 0x0156A588,
+  .ALLPROC_addr                    = 0x022BBE80,
+  .SBL_DRIVER_MAPPED_PAGES_addr    = 0x0266AC68,
+  .SBL_PFS_SX_addr                 = 0x02679040,
+  .SBL_KEYMGR_KEY_SLOTS_addr       = 0x02694570,
+  .SBL_KEYMGR_KEY_RBTREE_addr      = 0x02694580,
+  .SBL_KEYMGR_BUF_VA_addr          = 0x02698000,
+  .SBL_KEYMGR_BUF_GVA_addr         = 0x02698808,
+  .FPU_CTX_addr                    = 0x02694080,
+  .SYSENT_addr                     = 0x0111E000,
 
   // common
-  .memcmp_addr                     = 0x0,
-  ._sx_xlock_addr                  = 0x0,
-  ._sx_xunlock_addr                = 0x0,
-  .malloc_addr                     = 0x0,
-  .free_addr                       = 0x0,
-  .strstr_addr                     = 0x0,
-  .fpu_kern_enter_addr             = 0x0,
-  .fpu_kern_leave_addr             = 0x0,
-  .memcpy_addr                     = 0x0,
-  .memset_addr                     = 0x0,
-  .strlen_addr                     = 0x0,
-  .printf_addr                     = 0x0,
-  .eventhandler_register_addr      = 0x0,
+  .memcmp_addr                     = 0x00207E40,
+  ._sx_xlock_addr                  = 0x000426C0,
+  ._sx_xunlock_addr                = 0x00042880,
+  .malloc_addr                     = 0x0000D7A0,
+  .free_addr                       = 0x0000D9A0,
+  .strstr_addr                     = 0x004817F0,
+  .fpu_kern_enter_addr             = 0x0036B6E0,
+  .fpu_kern_leave_addr             = 0x0036B7D0,
+  .memcpy_addr                     = 0x003C15B0,
+  .memset_addr                     = 0x001687D0,
+  .strlen_addr                     = 0x002433E0,
+  .printf_addr                     = 0x00123280,
+  .eventhandler_register_addr      = 0x00402E80,
 
   // Fself
-  .sceSblACMgrGetPathId_addr       = 0x0,
-  .sceSblServiceMailbox_addr       = 0x0,
-  .sceSblAuthMgrSmIsLoadable2_addr = 0x0,
-  ._sceSblAuthMgrGetSelfInfo_addr  = 0x0,
-  ._sceSblAuthMgrSmStart_addr      = 0x0,
-  .sceSblAuthMgrVerifyHeader_addr  = 0x0,
+  .sceSblACMgrGetPathId_addr       = 0x00233C70,
+  .sceSblServiceMailbox_addr       = 0x0064CC20,
+  .sceSblAuthMgrSmIsLoadable2_addr = 0x0065D7A0,
+  ._sceSblAuthMgrGetSelfInfo_addr  = 0x0065E010,
+  ._sceSblAuthMgrSmStart_addr      = 0x0065E490,
+  .sceSblAuthMgrVerifyHeader_addr  = 0x0065D800,
 
   // Fpkg
-  .RsaesPkcs1v15Dec2048CRT_addr    = 0x0,
-  .Sha256Hmac_addr                 = 0x0,
-  .AesCbcCfb128Encrypt_addr        = 0x0,
-  .AesCbcCfb128Decrypt_addr        = 0x0,
-  .sceSblDriverSendMsg_0_addr      = 0x0,
-  .sceSblPfsSetKeys_addr           = 0x0,
-  .sceSblKeymgrSetKeyStorage_addr  = 0x0,
-  .sceSblKeymgrSetKeyForPfs_addr   = 0x0,
-  .sceSblKeymgrCleartKey_addr      = 0x0,
-  .sceSblKeymgrSmCallfunc_addr     = 0x0,
+  .RsaesPkcs1v15Dec2048CRT_addr    = 0x001D6050,
+  .Sha256Hmac_addr                 = 0x00335B70,
+  .AesCbcCfb128Encrypt_addr        = 0x003C0320,
+  .AesCbcCfb128Decrypt_addr        = 0x003C0550,
+  .sceSblDriverSendMsg_0_addr      = 0x00637AE0,
+  .sceSblPfsSetKeys_addr           = 0x00641520,
+  .sceSblKeymgrSetKeyStorage_addr  = 0x00646E00,
+  .sceSblKeymgrSetKeyForPfs_addr   = 0x00649800,
+  .sceSblKeymgrCleartKey_addr      = 0x00649B80,
+  .sceSblKeymgrSmCallfunc_addr     = 0x006493D0,
 
   // Patch
-  .vmspace_acquire_ref_addr        = 0x0,
-  .vmspace_free_addr               = 0x0,
-  .vm_map_lock_read_addr           = 0x0,
-  .vm_map_unlock_read_addr         = 0x0,
-  .vm_map_lookup_entry_addr        = 0x0,
-  .proc_rwmem_addr                 = 0x0,
+  .vmspace_acquire_ref_addr        = 0x0044CB90,
+  .vmspace_free_addr               = 0x0044C9C0,
+  .vm_map_lock_read_addr           = 0x0044CD40,
+  .vm_map_unlock_read_addr         = 0x0044CD90,
+  .vm_map_lookup_entry_addr        = 0x0044D330,
+  .proc_rwmem_addr                 = 0x0010EE10,
 
   // Fself hooks
-  .sceSblAuthMgrIsLoadable__sceSblACMgrGetPathId_hook        = 0x0,
-  .sceSblAuthMgrIsLoadable2_hook                             = 0x0,
-  .sceSblAuthMgrVerifyHeader_hook1                           = 0x0,
-  .sceSblAuthMgrVerifyHeader_hook2                           = 0x0,
-  .sceSblAuthMgrSmLoadSelfSegment__sceSblServiceMailbox_hook = 0x0,
-  .sceSblAuthMgrSmLoadSelfBlock__sceSblServiceMailbox_hook   = 0x0,
+  .sceSblAuthMgrIsLoadable__sceSblACMgrGetPathId_hook        = 0x006591BC,
+  .sceSblAuthMgrIsLoadable2_hook                             = 0x0065930F,
+  .sceSblAuthMgrVerifyHeader_hook1                           = 0x00659AC6,
+  .sceSblAuthMgrVerifyHeader_hook2                           = 0x0065A758,
+  .sceSblAuthMgrSmLoadSelfSegment__sceSblServiceMailbox_hook = 0x0066092A,
+  .sceSblAuthMgrSmLoadSelfBlock__sceSblServiceMailbox_hook   = 0x00661571,
 
   // Fpkg hooks
-  .sceSblKeymgrSetKeyStorage__sceSblDriverSendMsg_hook       = 0x0,
-  .sceSblKeymgrInvalidateKey__sx_xlock_hook                  = 0x0,
-  .sceSblKeymgrSmCallfunc_npdrm_decrypt_isolated_rif_hook    = 0x0,
-  .sceSblKeymgrSmCallfunc_npdrm_decrypt_rif_new_hook         = 0x0,
-  .mountpfs__sceSblPfsSetKeys_hook1                          = 0x0,
-  .mountpfs__sceSblPfsSetKeys_hook2                          = 0x0,
+  .sceSblKeymgrSetKeyStorage__sceSblDriverSendMsg_hook       = 0x00646EA5,
+  .sceSblKeymgrInvalidateKey__sx_xlock_hook                  = 0x0064AA3D,
+  .sceSblKeymgrSmCallfunc_npdrm_decrypt_isolated_rif_hook    = 0x00669500,
+  .sceSblKeymgrSmCallfunc_npdrm_decrypt_rif_new_hook         = 0x0066A313,
+  .mountpfs__sceSblPfsSetKeys_hook1                          = 0x006CDF15,
+  .mountpfs__sceSblPfsSetKeys_hook2                          = 0x006CE141,
 
   // SceShellUI patches - debug patches - libkernel_sys.sprx
-  .sceSblRcMgrIsAllowDebugMenuForSettings_patch              = 0x0,
-  .sceSblRcMgrIsStoreMode_patch                              = 0x0,
+  .sceSblRcMgrIsAllowDebugMenuForSettings_patch              = 0x0001D670,
+  .sceSblRcMgrIsStoreMode_patch                              = 0x0001D9D0,
 
   // SceShellUI patches - remote play patches
-  .CreateUserForIDU_patch                                    = 0x0, // system_ex\app\NPXS20001\eboot.bin
-  .remote_play_menu_patch                                    = 0x0, // system_ex\app\NPXS20001\psm\Application\app.exe.sprx
+  .CreateUserForIDU_patch                                    = 0x001A0900, // system_ex\app\NPXS20001\eboot.bin
+  .remote_play_menu_patch                                    = 0x00EC8291, // system_ex\app\NPXS20001\psm\Application\app.exe.sprx
 
   // SceRemotePlay patches - remote play patches - system\vsh\app\NPXS21006
-  .SceRemotePlay_patch1                                      = 0x0,
-  .SceRemotePlay_patch2                                      = 0x0,
+  .SceRemotePlay_patch1                                      = 0x0010C6D4,
+  .SceRemotePlay_patch2                                      = 0x0010C6EF,
 
   // SceShellCore patches - call sceKernelIsGenuineCEX
-  .sceKernelIsGenuineCEX_patch1    = 0x0,
-  .sceKernelIsGenuineCEX_patch2    = 0x0,
-  .sceKernelIsGenuineCEX_patch3    = 0x0,
-  .sceKernelIsGenuineCEX_patch4    = 0x0,
+  .sceKernelIsGenuineCEX_patch1    = 0x00189602,
+  .sceKernelIsGenuineCEX_patch2    = 0x008355A2,
+  .sceKernelIsGenuineCEX_patch3    = 0x008803F2,
+  .sceKernelIsGenuineCEX_patch4    = 0x00A12AF2,
 
   // SceShellCore patches - call nidf_libSceDipsw
-  .nidf_libSceDipsw_patch1         = 0x0,
-  .nidf_libSceDipsw_patch2         = 0x0,
-  .nidf_libSceDipsw_patch3         = 0x0,
-  .nidf_libSceDipsw_patch4         = 0x0,
+  .nidf_libSceDipsw_patch1         = 0x00189630,
+  .nidf_libSceDipsw_patch2         = 0x00254107,
+  .nidf_libSceDipsw_patch3         = 0x008355D0,
+  .nidf_libSceDipsw_patch4         = 0x00A12B20,
 
   // SceShellCore patches - bypass firmware checks
-  .check_disc_root_param_patch     = 0x0,
-  .app_installer_patch             = 0x0,
-  .check_system_version            = 0x0,
-  .check_title_system_update_patch = 0x0,
+  .check_disc_root_param_patch     = 0x00149AFD,
+  .app_installer_patch             = 0x00149BF0,
+  .check_system_version            = 0x003DB6F8,
+  .check_title_system_update_patch = 0x003DECC0,
 
   // SceShellCore patches - enable remote pkg installer
-  .enable_data_mount_patch         = 0x0,
+  .enable_data_mount_patch         = 0x0033943E,
 
   // SceShellCore patches - enable VR without spoof
-  .enable_psvr_patch               = 0x0,
+  .enable_psvr_patch               = 0x00DDDCB0,
 
   // SceShellCore patches - enable fpkg
-  .enable_fpkg_patch               = 0x0,
+  .enable_fpkg_patch               = 0x003EFCF0,
 
   // SceShellCore patches - use `free` prefix instead `fake`
-  .fake_free_patch                 = 0x0,
+  .fake_free_patch                 = 0x00FD2B51,
 
   // SceShellCore patches - enable official external HDD support
-  .pkg_installer_patch             = 0x0,
-  .ext_hdd_patch                   = 0x0,
+  .pkg_installer_patch             = 0x009FB271,
+  .ext_hdd_patch                   = 0x00606A0D,
 
   // SceShellCore patches - enable debug trophies
-  .debug_trophies_patch            = 0x0,
+  .debug_trophies_patch            = 0x00726829,
 
   // SceShellCore patches - disable screenshot block
-  .disable_screenshot_patch        = 0x0,
+  .disable_screenshot_patch        = 0x000DD2A6,
 
   // Process structure offsets
-  .proc_p_comm_offset = 0x44C,
-  .proc_path_offset   = 0x46C,
+  .proc_p_comm_offset = 0x454,
+  .proc_path_offset   = 0x474,
 };
 
 // clang-format on


### PR DESCRIPTION
Should have coverage from 4.74 through 12.52. For exploit fixes we assume Lua-Lapse and PSFree-Lapse patch the kernel as expected (And hopefully any future exploits going forward do the same).