### PR TITLE
Little Fix 

### DIFF
--- a/installer/source/main.c
+++ b/installer/source/main.c
@@ -124,7 +124,7 @@ int _main(struct thread *td) {
 
   bool kill_ui = false;
   int sleep_sec = 0;
-  const int wait_sec = 5;
+//  const int wait_sec = 5;
   const int u_to_sec = 1000 * 1000;
 
   init_config(&config);
@@ -195,16 +195,16 @@ int _main(struct thread *td) {
     InstallShellCoreCodeForAppinfo();
   }
 
-  printf_notification("Welcome to HEN%s%s %s",
+  printf_notification("Welcome to HEN%s %s\n %s",
     config.enable_plugins ? "" : "-Lite",
-    kill_ui ? " (Shell UI restarting)" : " (Shell UI not restarting)",
-    VERSION);
+    VERSION,
+    kill_ui ? " (Shell UI restarting)" : " (Shell UI not restarting)");
 
   const char *proc = kill_ui ? "SceShellUI" : NULL;
-  if (kill_ui) {
-    usleep(sleep_sec * u_to_sec);
-    printf_notification("HEN will restart %s\nin %d seconds...", proc, sleep_sec);
-  }
+//  if (kill_ui) {
+//    usleep(sleep_sec * u_to_sec);
+//    printf_notification("HEN will restart %s\nin %d seconds...", proc, sleep_sec);
+//  }
 
 #ifdef DEBUG_SOCKET
   printf_debug("Closing socket...\n");
@@ -214,7 +214,10 @@ int _main(struct thread *td) {
   usleep(sleep_sec * u_to_sec);
   // this was chosen because SceShellCore will try to restart this daemon if it crashes
   // or manually killed in this case
-  kill_proc("ScePartyDaemon");
+  if (config.enable_plugins && file_exists(PRX_SERVER_PATH)) {
+    kill_proc("ScePartyDaemon");
+  }
+  // SceShellUI is also monitored by SceShellCore
   kill_proc(proc);
 
   return 0;

--- a/installer/source/main.c
+++ b/installer/source/main.c
@@ -195,8 +195,9 @@ int _main(struct thread *td) {
     InstallShellCoreCodeForAppinfo();
   }
 
-  printf_notification("Welcome to HEN%s %s",
+  printf_notification("Welcome to HEN%s%s %s",
     config.enable_plugins ? "" : "-Lite",
+    kill_ui ? " (Shell UI restarting)" : " (Shell UI not restarting)",
     VERSION);
 
   const char *proc = kill_ui ? "SceShellUI" : NULL;


### PR DESCRIPTION
Hello Illusion
On 3. Payload Injection with enabled Plugins he did not restart the ShellUI .. in my Video i only Injected two times ... and the problem is it was all the time like enabled_plugins = 0 (HEN Lite)  even the enabled_plugins = 1 was set , only on the first Injection he did the ShellUi Kill.... so it was not 100% right working i fixed it now it works fine.  

Sorry, I’m not that familiar with GitHub, but this main.c is good and works as it should

Default = Hen Full 
if you disable the Plugins it is Hen Lite ... and for getting back to Hen Full you have to delete hen.ini file or the whole hen folder under /data  (because no menu in systemsettings for reenable the Plugins)

Just let you know. 

One more question: Is it not possible to display the Debug Menu and the Hen Settings without restarting the Shell UI? Normally, the Debug Menu is shown without a Shell UI restart, right? I mean, not in the main menu, but simply in the System Settings menu?

have a nice weekend




EDIT:
maybe i deleted to mutch for this step (ver_mismatch)
but yes the Function between Hen Full (default) and Hen Lite is working right with that main.c 
You’re the master — just so you know, it didn’t work quite right before, but now it works.

```  if (!config_exists || ver_mismatch) {
    printf_debug("Config missing or version mismatch -> writing new config...\n");```
