### PR TITLE
Fix kill_ui and sleep_sec

### DIFF
--- a/installer/source/main.c
+++ b/installer/source/main.c
@@ -124,10 +124,10 @@ int _main(struct thread *td) {
 
   const bool ver_match = config.config_version != DEFAULT_CONFIG_VERSION;
   const bool found_ver = found_version == 0;
-  bool kill_ui = false;
-  int sleep_sec = 0;
+  bool kill_ui = config.enable_plugins;
   const int wait_sec = 5;
   const int u_to_sec = 1000 * 1000;
+  int sleep_sec = kill_ui ? wait_sec : 1;
   if (file_exists(HDD_INI_PATH) && (ver_match || found_ver)) {
     const char *reason = " unknown!";
     if (ver_match) {
@@ -146,8 +146,6 @@ int _main(struct thread *td) {
     printf_notification("Config version (%d/%d)%s\n"
                         "Updating settings file on %s%s...", config.config_version, DEFAULT_CONFIG_VERSION, reason, "HDD", found_usb ? " and USB" : "");
     init_config(&config);
-    kill_ui = config.enable_plugins == true;
-    sleep_sec = kill_ui ? wait_sec : 1;
     // sleep so user can see welcome message before shellui restarts
     // always sleep for `wait_sec` so other notifications aren't shown
     usleep(wait_sec * u_to_sec);


### PR DESCRIPTION
In the latest versions of HEN, the UI doesn't restart. (https://github.com/Scene-Collective/ps4-hen/issues/46)

This PR fixes the kill_ui check and properly sets the value for sleep_sec, which previously would be stuck to 0.

This change was tested on a 9.00 PS4.